### PR TITLE
"send-event" command added

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,20 +69,31 @@ Watch incoming events:
 tmcli watch
 ```
 
+Create transformation:
+```
+tmcli create transformation --source foo-awssqssource
+```
+
 Create target and trigger:
 
 ```
 tmcli create target cloudevents --endpoint https://sockeye-tzununbekov.dev.triggermesh.io
-tmcli create trigger --source foo-awssqssource --target foo-cloudeventstarget
+tmcli create trigger --source foo-transformation --target foo-cloudeventstarget
 ```
 
 Or, in one command:
 
 ```
-tmcli create target cloudevents --endpoint https://sockeye-tzununbekov.dev.triggermesh.io --source foo-awssqssource
+tmcli create target cloudevents --endpoint https://sockeye-tzununbekov.dev.triggermesh.io --source foo-transformation
 ```
 
 Open sockeye [web-interface](https://sockeye-tzununbekov.dev.triggermesh.io), send the message to SQS queue specified in the source creation step and observe the received CloudEvent in the sockeye tab.
+
+Or send test event manually:
+
+```
+tmcli send-event --eventType com.amazon.sqs.message '{"hello":"world"}'
+```
 
 Stop event flow:
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/triggermesh/tmcli/cmd/describe"
 	"github.com/triggermesh/tmcli/cmd/dump"
 	"github.com/triggermesh/tmcli/cmd/list"
+	"github.com/triggermesh/tmcli/cmd/sendevent"
 	"github.com/triggermesh/tmcli/cmd/start"
 	"github.com/triggermesh/tmcli/cmd/stop"
 	"github.com/triggermesh/tmcli/cmd/watch"
@@ -84,6 +85,7 @@ func NewRootCommand() *cobra.Command {
 	rootCmd.AddCommand(dump.NewCmd())
 	rootCmd.AddCommand(describe.NewCmd())
 	rootCmd.AddCommand(list.NewCmd())
+	rootCmd.AddCommand(sendevent.NewCmd())
 	rootCmd.AddCommand(start.NewCmd())
 	rootCmd.AddCommand(stop.NewCmd())
 	rootCmd.AddCommand(watch.NewCmd())

--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -23,8 +23,9 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/triggermesh/tmcli/pkg/manifest"
 	"gopkg.in/yaml.v3"
+
+	"github.com/triggermesh/tmcli/pkg/manifest"
 )
 
 const manifestFile = "manifest.yaml"

--- a/cmd/sendevent/sendevent.go
+++ b/cmd/sendevent/sendevent.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sendevent
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	tmbroker "github.com/triggermesh/tmcli/pkg/triggermesh/broker"
+)
+
+const (
+	defaultEventType   = "triggermesh-local-event"
+	defaultEventSource = "triggermesh-cli"
+)
+
+type SendOptions struct {
+	Context   string
+	ConfigDir string
+	EventType string
+}
+
+func NewCmd() *cobra.Command {
+	o := &SendOptions{}
+	sendCmd := &cobra.Command{
+		Use:   "send-event <data> [--eventType <type>]",
+		Short: "Send CloudEvent to the broker",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.Context = viper.GetString("context")
+			configDir, err := cmd.Flags().GetString("config")
+			if err != nil {
+				return err
+			}
+			o.ConfigDir = configDir
+			return o.send(strings.Join(args, " "))
+		},
+	}
+	sendCmd.Flags().StringVar(&o.EventType, "eventType", defaultEventType, "CloudEvent Type attribute")
+	return sendCmd
+}
+
+func (o *SendOptions) send(data string) error {
+	ctx := context.Background()
+	broker, err := tmbroker.New(o.Context, o.ConfigDir)
+	if err != nil {
+		return fmt.Errorf("broker object: %v", err)
+	}
+	port, err := broker.GetPort(ctx)
+	if err != nil {
+		return fmt.Errorf("broker socket: %v", err)
+	}
+
+	c, err := cloudevents.NewClientHTTP()
+	if err != nil {
+		return fmt.Errorf("cloudevents client, %w", err)
+	}
+
+	event := cloudevents.NewEvent()
+	event.SetSource(defaultEventSource)
+	event.SetType(o.EventType)
+	event.SetData(cloudevents.ApplicationJSON, data)
+
+	brokerEndpoint := fmt.Sprintf("http://localhost:%s", port)
+	fmt.Printf("%s -> %s\n", data, brokerEndpoint)
+	result := c.Send(cloudevents.ContextWithTarget(ctx, brokerEndpoint), event)
+	if cloudevents.IsUndelivered(result) {
+		return fmt.Errorf("send event: %w", result)
+	}
+	fmt.Println("OK")
+	return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/triggermesh/tmcli
 go 1.19
 
 require (
+	github.com/cloudevents/sdk-go/v2 v2.10.1
 	github.com/docker/docker v20.10.12+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/spf13/cobra v1.5.0
@@ -12,7 +13,6 @@ require (
 	k8s.io/api v0.23.5
 	k8s.io/apimachinery v0.23.5
 	k8s.io/kube-openapi v0.0.0-20220124234850-424119656bbf
-	knative.dev/eventing v0.31.1-0.20220523181303-c3e13967001f
 
 )
 
@@ -52,8 +52,6 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cloudevents/sdk-go/observability/opencensus/v2 v2.6.1 // indirect
-	github.com/cloudevents/sdk-go/sql/v2 v2.8.0 // indirect
-	github.com/cloudevents/sdk-go/v2 v2.10.1 // indirect
 	github.com/containerd/containerd v1.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dimchansky/utfbom v1.1.1 // indirect
@@ -146,6 +144,7 @@ require (
 	k8s.io/client-go v11.0.1-0.20190805182717-6502b5e7b1b5+incompatible // indirect
 	k8s.io/klog/v2 v2.60.1-0.20220317184644-43cc75f9ae89 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
+	knative.dev/eventing v0.31.1-0.20220523181303-c3e13967001f // indirect
 	knative.dev/networking v0.0.0-20220412163509-1145ec58c8be // indirect
 	knative.dev/pkg v0.0.0-20220525153005-18f69958870f // indirect
 	knative.dev/serving v0.31.0 // indirect


### PR DESCRIPTION
New `send-event` command added. The command input argument is set to the outgoing cloudevent's data. The optional `eventType` attribute overrides the default value of the event type attribute.
```
$ tmcli send-event --eventType com.amazon.sqs.message '{"hello":"world"}'
{"hello":"world"} -> http://localhost:59534
OK
```
Closes #23.