### PR TITLE
Version cmd added

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -32,6 +32,7 @@ import (
 	"github.com/triggermesh/tmctl/cmd/sendevent"
 	"github.com/triggermesh/tmctl/cmd/start"
 	"github.com/triggermesh/tmctl/cmd/stop"
+	"github.com/triggermesh/tmctl/cmd/version"
 	"github.com/triggermesh/tmctl/cmd/watch"
 )
 
@@ -42,7 +43,7 @@ const (
 	configDir = ".triggermesh/cli"
 )
 
-func NewRootCommand() *cobra.Command {
+func NewRootCommand(ver, commit string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "tmctl",
 		Short: "A command line interface to build event-driven applications",
@@ -69,6 +70,7 @@ Find more information at: https://docs.triggermesh.io`,
 	rootCmd.AddCommand(start.NewCmd())
 	rootCmd.AddCommand(stop.NewCmd())
 	rootCmd.AddCommand(watch.NewCmd())
+	rootCmd.AddCommand(version.NewCmd(ver, commit))
 
 	return rootCmd
 }

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+
+	"github.com/triggermesh/tmctl/pkg/docker"
+)
+
+func NewCmd(ver, commit string) *cobra.Command {
+	versionCmd := &cobra.Command{
+		Use:   "version",
+		Short: "CLI version information",
+		Run: func(_ *cobra.Command, _ []string) {
+			fmt.Println("CLI:")
+			fmt.Println(" Version: ", ver)
+			fmt.Println(" Commit: ", commit)
+			fmt.Printf(" OS/Arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
+			fmt.Println("\nDocker:")
+			fmt.Println(" ", dockerVersion())
+		},
+	}
+	return versionCmd
+}
+
+func dockerVersion() string {
+	client, err := docker.NewClient()
+	if err != nil {
+		return fmt.Sprintf("Not available (%v)", err)
+	}
+	ver, err := client.ServerVersion(context.Background())
+	if err != nil {
+		return fmt.Sprintf("Not available (%v)", err)
+	}
+	return ver.Platform.Name
+}

--- a/main.go
+++ b/main.go
@@ -18,14 +18,17 @@ package main
 
 import (
 	"log"
-	"os"
 
 	"github.com/triggermesh/tmctl/cmd"
 )
 
+var (
+	Version string = "dev"
+	Commit  string = "unknown"
+)
+
 func main() {
-	if err := cmd.NewRootCommand().Execute(); err != nil {
-		log.Println(err)
-		os.Exit(1)
+	if err := cmd.NewRootCommand(Version, Commit).Execute(); err != nil {
+		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
`tmctl version` prints the binary information. Version and commit hash should be passed as build flags:
```
go install -ldflags="-X 'main.Version=$(git tag -l | tail -1)' -X 'main.Commit=$(git rev-parse HEAD)'"
```

Closes #32