### PR TITLE
Log output update, trigger add/update fixes

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -12,8 +12,6 @@ builds:
       - amd64
       - arm64
       - arm
-    goarm:
-      - "7"
     ignore:
       - goos: windows
         goarch: arm64

--- a/README.md
+++ b/README.md
@@ -21,18 +21,10 @@ brew install tmctl
 
 ### Pre-built binary
 
-For MacOS on Apple Silicon chips:
+Linux, MacOS:
 
 ```
-curl -L https://github.com/triggermesh/tmctl/releases/download/v0.0.1/tmctl_0.0.1_darwin_arm64 -o tmctl \
-    && chmod +x tmctl \
-    && sudo mv tmctl /usr/local/bin
-```
-
-Linux, AMD64:
-
-```
-curl -L https://github.com/triggermesh/tmctl/releases/download/v0.0.1/tmctl_0.0.1_linux_amd64 -o tmctl \
+curl -L https://github.com/triggermesh/tmctl/releases/download/v0.0.1/tmctl_0.0.1_$(uname -m -o | awk '{print tolower($1)"_"$2}') -o tmctl \
     && chmod +x tmctl \
     && sudo mv tmctl /usr/local/bin
 ```

--- a/cmd/create/broker.go
+++ b/cmd/create/broker.go
@@ -19,12 +19,12 @@ package create
 import (
 	"context"
 	"fmt"
-	"log"
 	"path"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/triggermesh/tmctl/pkg/log"
 	"github.com/triggermesh/tmctl/pkg/output"
 	"github.com/triggermesh/tmctl/pkg/triggermesh"
 	tmbroker "github.com/triggermesh/tmctl/pkg/triggermesh/components/broker"

--- a/cmd/create/source.go
+++ b/cmd/create/source.go
@@ -19,12 +19,12 @@ package create
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/triggermesh/tmctl/pkg/log"
 	"github.com/triggermesh/tmctl/pkg/output"
 	"github.com/triggermesh/tmctl/pkg/triggermesh"
 	"github.com/triggermesh/tmctl/pkg/triggermesh/components"

--- a/cmd/create/trigger.go
+++ b/cmd/create/trigger.go
@@ -18,11 +18,11 @@ package create
 
 import (
 	"fmt"
-	"log"
 
 	"github.com/spf13/cobra"
 
 	"github.com/triggermesh/tmctl/pkg/completion"
+	"github.com/triggermesh/tmctl/pkg/log"
 	"github.com/triggermesh/tmctl/pkg/triggermesh"
 	"github.com/triggermesh/tmctl/pkg/triggermesh/components"
 	tmbroker "github.com/triggermesh/tmctl/pkg/triggermesh/components/broker"

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -19,7 +19,6 @@ package delete
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"path"
 	"strings"
@@ -32,6 +31,7 @@ import (
 	"github.com/triggermesh/tmctl/pkg/completion"
 	"github.com/triggermesh/tmctl/pkg/docker"
 	"github.com/triggermesh/tmctl/pkg/kubernetes"
+	"github.com/triggermesh/tmctl/pkg/log"
 	"github.com/triggermesh/tmctl/pkg/manifest"
 	"github.com/triggermesh/tmctl/pkg/triggermesh"
 	"github.com/triggermesh/tmctl/pkg/triggermesh/components"

--- a/cmd/describe/describe.go
+++ b/cmd/describe/describe.go
@@ -131,7 +131,7 @@ func (o DescribeOptions) describe(b string) error {
 						et = []string{"*"}
 					}
 					producersPrint = true
-					fmt.Fprintf(producers, "%s\tkn-service (%s)\t%s\t%s\n", c.GetName(), service.Image, strings.Join(et, ", "), status(c))
+					fmt.Fprintf(producers, "%s\tservice (%s)\t%s\t%s\n", c.GetName(), service.Image, strings.Join(et, ", "), status(c))
 				}
 				if service.IsTarget() {
 					et, _ := c.(triggermesh.Consumer).ConsumedEventTypes()
@@ -139,7 +139,7 @@ func (o DescribeOptions) describe(b string) error {
 						et = []string{"*"}
 					}
 					consumersPrint = true
-					fmt.Fprintf(consumers, "%s\tkn-service (%s)\t%s\t%s\n", c.GetName(), service.Image, strings.Join(et, ", "), status(c))
+					fmt.Fprintf(consumers, "%s\tservice (%s)\t%s\t%s\n", c.GetName(), service.Image, strings.Join(et, ", "), status(c))
 				}
 			}
 			// transformation

--- a/cmd/sendevent/sendevent.go
+++ b/cmd/sendevent/sendevent.go
@@ -119,11 +119,13 @@ func (o *SendOptions) send(eventType, target, data string) error {
 	}
 
 	brokerEndpoint := fmt.Sprintf("http://localhost:%s", port)
-	fmt.Printf("Request:\n%s\nDestination: %s(%s)\n", event.String(), target, brokerEndpoint)
+	fmt.Printf("Destination: %s(%s)\n", target, brokerEndpoint)
+	fmt.Printf("Request:\n------\n%s------", event.String())
 	result := c.Send(cloudevents.ContextWithTarget(ctx, brokerEndpoint), event)
-	if cloudevents.IsUndelivered(result) {
-		return fmt.Errorf("send event: %w", result)
+	response := "\033[92mOK\033[39m"
+	if !cloudevents.IsACK(result) {
+		response = fmt.Sprintf("\u001b[31mError\033[39m(%s)", result.Error())
 	}
-	fmt.Printf("Response: %s \033[92mOK\033[39m\n", result)
+	fmt.Printf("\nResponse: %s\n", response)
 	return nil
 }

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -19,12 +19,12 @@ package start
 import (
 	"context"
 	"fmt"
-	"log"
 	"path"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/triggermesh/tmctl/pkg/log"
 	"github.com/triggermesh/tmctl/pkg/manifest"
 	"github.com/triggermesh/tmctl/pkg/triggermesh"
 	"github.com/triggermesh/tmctl/pkg/triggermesh/components"

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -19,13 +19,13 @@ package stop
 import (
 	"context"
 	"fmt"
-	"log"
 	"path"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/triggermesh/tmctl/pkg/docker"
+	"github.com/triggermesh/tmctl/pkg/log"
 	"github.com/triggermesh/tmctl/pkg/manifest"
 	"github.com/triggermesh/tmctl/pkg/triggermesh"
 	tmbroker "github.com/triggermesh/tmctl/pkg/triggermesh/components/broker"

--- a/cmd/watch/watch.go
+++ b/cmd/watch/watch.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/signal"
 	"path"
@@ -31,6 +30,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
+	"github.com/triggermesh/tmctl/pkg/log"
 	"github.com/triggermesh/tmctl/pkg/wiretap"
 )
 
@@ -74,6 +74,7 @@ func (o *WatchOptions) watch(broker string) error {
 			log.Printf("Cleanup: %v", err)
 		}
 	}()
+	log.Println("Connecting to broker")
 	logs, err := w.CreateAdapter(ctx)
 	if err != nil {
 		return fmt.Errorf("create container: %w", err)
@@ -84,7 +85,7 @@ func (o *WatchOptions) watch(broker string) error {
 	log.Println("Watching...")
 	go listenLogs(logs, c)
 	<-c
-	log.Println("Exiting")
+	log.Println("Cleaning up")
 	return nil
 }
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -14,20 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
+package log
 
 import (
-	"github.com/triggermesh/tmctl/cmd"
-	"github.com/triggermesh/tmctl/pkg/log"
+	glog "log"
+
+	"github.com/spf13/viper"
 )
 
-var (
-	Version string = "dev"
-	Commit  string = "unknown"
-)
-
-func main() {
-	if err := cmd.NewRootCommand(Version, Commit).Execute(); err != nil {
-		log.Fatal(err)
+var broker = func() string {
+	if broker := viper.GetString("context"); broker != "" {
+		return broker
 	}
+	return "-"
+}
+
+// Println is standard's log output supplied with the broker name.
+func Println(message string) {
+	glog.Printf("%s | %s", broker(), message)
+}
+
+// Printf is standard's log formattable output supplied with the broker name.
+func Printf(format string, v ...any) {
+	glog.Printf(broker()+" | "+format, v...)
+}
+
+// Fatal is the local fatal function.
+func Fatal(v ...any) {
+	glog.Fatal(v...)
 }

--- a/pkg/triggermesh/components/components.go
+++ b/pkg/triggermesh/components/components.go
@@ -71,7 +71,19 @@ func GetObject(name, crdFile, version string, manifest *manifest.Manifest) (trig
 				env := container.(map[string]interface{})["env"]
 				if env != nil {
 					for _, v := range env.([]interface{}) {
-						params[v.(map[string]interface{})["name"].(string)] = v.(map[string]interface{})["value"].(string)
+						val, ok := v.(map[string]interface{})
+						if !ok {
+							continue
+						}
+						name, ok := val["name"]
+						if !ok {
+							continue
+						}
+						value, ok := val["value"]
+						if !ok {
+							continue
+						}
+						params[name.(string)] = value.(string)
 					}
 				}
 				return service.New(name, image, broker, service.Role(role), params), nil

--- a/pkg/triggermesh/components/service/service.go
+++ b/pkg/triggermesh/components/service/service.go
@@ -218,7 +218,7 @@ func New(name, image, broker string, role Role, params map[string]string) trigge
 }
 
 func paramsToEnv(params map[string]string) []interface{} {
-	var env []interface{}
+	env := make([]interface{}, 0, len(params))
 	for k, v := range params {
 		env = append(env, map[string]interface{}{
 			"name":  strings.ToUpper(k),

--- a/pkg/triggermesh/crd/crd.go
+++ b/pkg/triggermesh/crd/crd.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path"
@@ -28,6 +27,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/triggermesh/tmctl/pkg/log"
 )
 
 const (


### PR DESCRIPTION
1. Inplace `log` package replacement for additional context output
2. Triggers update/cleanup logic fix for transformation/targets creation. Closes #126 
3. `--from-image` services restart check fixed