### PR TITLE
Watch broker config, fix CRD resources listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ brew install tmctl
 Linux, MacOS:
 
 ```
-curl -L https://github.com/triggermesh/tmctl/releases/download/v0.0.1/tmctl_0.0.1_$(uname -m -o | awk '{print tolower($1)"_"$2}') -o tmctl \
+export TMCTL_VERSION=$(curl -s -I HEAD https://github.com/triggermesh/tmctl/releases/latest | grep "location:" | awk -F / '{print $NF}')
+curl -L https://github.com/triggermesh/tmctl/releases/download/$TMCTL_VERSION/tmctl_${TMCTL_VERSION:1}_$(uname -m -o | awk '{print tolower($1)"_"$2}') -o tmctl \
     && chmod +x tmctl \
     && sudo mv tmctl /usr/local/bin
 ```

--- a/pkg/docker/client.go
+++ b/pkg/docker/client.go
@@ -63,7 +63,12 @@ func NewClient() (*client.Client, error) {
 }
 
 func (c *Container) Logs(ctx context.Context, client *client.Client) (io.ReadCloser, error) {
-	options := types.ContainerLogsOptions{ShowStdout: true, ShowStderr: true, Follow: true}
+	options := types.ContainerLogsOptions{
+		ShowStdout: true,
+		ShowStderr: true,
+		Follow:     true,
+		// start tailing new logs only
+		Since: (time.Now().Add(2 * time.Second).Format("2006-01-02T15:04:05.999999999Z07:00"))}
 	return client.ContainerLogs(ctx, c.ID, options)
 }
 
@@ -222,6 +227,7 @@ func (c *Container) LookupHostConfig(ctx context.Context, client *client.Client)
 	if err != nil {
 		return nil, err
 	}
+	c.ID = id
 	c.runtimeHostConfig = *jsn.HostConfig
 	c.runtimeContainerConfig = *jsn.Config
 	return c, nil

--- a/pkg/triggermesh/components/source/source.go
+++ b/pkg/triggermesh/components/source/source.go
@@ -240,7 +240,7 @@ func New(name, crdFile, kind, broker, version string, params interface{}) trigge
 
 	// kind initially can be awss3, webhook, etc.
 	k := strings.ToLower(kind)
-	if !strings.Contains(k, "source") {
+	if !strings.HasSuffix(k, "source") {
 		k = fmt.Sprintf("%ssource", kind)
 	}
 

--- a/pkg/triggermesh/components/target/target.go
+++ b/pkg/triggermesh/components/target/target.go
@@ -176,7 +176,7 @@ func New(name, crdFile, kind, broker, version string, params interface{}) trigge
 
 	// kind initially can be awss3, webhook, etc.
 	k := strings.ToLower(kind)
-	if !strings.Contains(k, "target") {
+	if !strings.HasSuffix(k, "target") {
 		k = fmt.Sprintf("%starget", kind)
 	}
 


### PR DESCRIPTION
1. User feedback: `tmctl watch` prints broker subscription updates,
2. Resource name check condition fixed, resolves #116.