### PR TITLE
Dump warning message

### DIFF
--- a/cmd/create/broker.go
+++ b/cmd/create/broker.go
@@ -30,7 +30,7 @@ import (
 	tmbroker "github.com/triggermesh/tmctl/pkg/triggermesh/components/broker"
 )
 
-func (o *CreateOptions) NewBrokerCmd() *cobra.Command {
+func (o *createOptions) NewBrokerCmd() *cobra.Command {
 	return &cobra.Command{
 		Use: "broker <name>",
 		// Short: "TriggerMesh broker",
@@ -44,7 +44,7 @@ func (o *CreateOptions) NewBrokerCmd() *cobra.Command {
 	}
 }
 
-func (o *CreateOptions) broker(name string) error {
+func (o *createOptions) broker(name string) error {
 	ctx := context.Background()
 
 	o.Manifest.Path = path.Join(o.ConfigBase, name, triggermesh.ManifestFile)

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -30,7 +30,7 @@ import (
 	"github.com/triggermesh/tmctl/pkg/triggermesh/crd"
 )
 
-type CreateOptions struct {
+type createOptions struct {
 	ConfigBase string
 	Context    string
 	Version    string
@@ -39,7 +39,7 @@ type CreateOptions struct {
 }
 
 func NewCmd() *cobra.Command {
-	o := &CreateOptions{}
+	o := &createOptions{}
 	createCmd := &cobra.Command{
 		Use:   "create <resource>",
 		Short: "Create TriggerMesh objects",
@@ -58,7 +58,7 @@ func NewCmd() *cobra.Command {
 	return createCmd
 }
 
-func (o *CreateOptions) initialize() {
+func (o *createOptions) initialize() {
 	o.ConfigBase = path.Dir(viper.ConfigFileUsed())
 	o.Context = viper.GetString("context")
 	o.Version = viper.GetString("triggermesh.version")
@@ -94,7 +94,7 @@ func argsToMap(args []string) map[string]string {
 	return result
 }
 
-func (o *CreateOptions) translateEventSource(eventSourcesFilter []string) ([]string, error) {
+func (o *createOptions) translateEventSource(eventSourcesFilter []string) ([]string, error) {
 	var result []string
 	for _, source := range eventSourcesFilter {
 		s, err := components.GetObject(source, o.CRD, o.Version, o.Manifest)

--- a/cmd/create/completion.go
+++ b/cmd/create/completion.go
@@ -27,7 +27,7 @@ import (
 	"github.com/triggermesh/tmctl/pkg/triggermesh/crd"
 )
 
-func (o *CreateOptions) sourcesCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func (o *createOptions) sourcesCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) == 0 {
 		sources, err := crd.ListSources(o.CRD)
 		if err != nil {
@@ -100,7 +100,7 @@ func (o *CreateOptions) sourcesCompletion(cmd *cobra.Command, args []string, toC
 	return append(spec, "--name\tOptional component name."), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
 }
 
-func (o *CreateOptions) targetsCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+func (o *createOptions) targetsCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 	if len(args) == 0 {
 		targets, err := crd.ListTargets(o.CRD)
 		if err != nil {

--- a/cmd/create/source.go
+++ b/cmd/create/source.go
@@ -34,7 +34,7 @@ import (
 	"github.com/triggermesh/tmctl/pkg/triggermesh/crd"
 )
 
-func (o *CreateOptions) NewSourceCmd() *cobra.Command {
+func (o *createOptions) NewSourceCmd() *cobra.Command {
 	return &cobra.Command{
 		Use: "source [kind]/[--from-image <image>][--name <name>]",
 		// Short:              "TriggerMesh source",
@@ -86,7 +86,7 @@ func (o *CreateOptions) NewSourceCmd() *cobra.Command {
 	}
 }
 
-func (o *CreateOptions) source(name, kind string, params map[string]string) error {
+func (o *createOptions) source(name, kind string, params map[string]string) error {
 	ctx := context.Background()
 	broker, err := tmbroker.New(o.Context, o.Manifest.Path)
 	if err != nil {
@@ -134,7 +134,7 @@ func (o *CreateOptions) source(name, kind string, params map[string]string) erro
 	return nil
 }
 
-func (o *CreateOptions) sourceFromImage(name, image string, params map[string]string) error {
+func (o *createOptions) sourceFromImage(name, image string, params map[string]string) error {
 	ctx := context.Background()
 	broker, err := tmbroker.New(o.Context, o.Manifest.Path)
 	if err != nil {

--- a/cmd/create/target.go
+++ b/cmd/create/target.go
@@ -36,7 +36,7 @@ import (
 	"github.com/triggermesh/tmctl/pkg/triggermesh/crd"
 )
 
-func (o *CreateOptions) NewTargetCmd() *cobra.Command {
+func (o *createOptions) NewTargetCmd() *cobra.Command {
 	return &cobra.Command{
 		Use: "target [kind]/[--from-image <image>][--name <name>][--source <name>,<name>...][--event-types <type>,<type>...]",
 		// Short:              "TriggerMesh target",
@@ -100,7 +100,7 @@ func (o *CreateOptions) NewTargetCmd() *cobra.Command {
 	}
 }
 
-func (o *CreateOptions) target(name, kind string, args map[string]string, eventSourcesFilter, eventTypesFilter []string) error {
+func (o *createOptions) target(name, kind string, args map[string]string, eventSourcesFilter, eventTypesFilter []string) error {
 	ctx := context.Background()
 
 	et, err := o.translateEventSource(eventSourcesFilter)
@@ -154,7 +154,7 @@ func (o *CreateOptions) target(name, kind string, args map[string]string, eventS
 	return nil
 }
 
-func (o *CreateOptions) createTrigger(name string, target triggermesh.Component, filter *eventingbroker.Filter) (triggermesh.Component, error) {
+func (o *createOptions) createTrigger(name string, target triggermesh.Component, filter *eventingbroker.Filter) (triggermesh.Component, error) {
 	trigger, err := tmbroker.NewTrigger(name, o.Context, o.ConfigBase, target, filter)
 	if err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func (o *CreateOptions) createTrigger(name string, target triggermesh.Component,
 	return trigger, nil
 }
 
-func (o *CreateOptions) updateTriggers(target triggermesh.Component) error {
+func (o *createOptions) updateTriggers(target triggermesh.Component) error {
 	triggers, err := tmbroker.GetTargetTriggers(target.GetName(), o.Context, o.ConfigBase)
 	if err != nil {
 		return fmt.Errorf("target triggers: %w", err)
@@ -182,7 +182,7 @@ func (o *CreateOptions) updateTriggers(target triggermesh.Component) error {
 	return nil
 }
 
-func (o *CreateOptions) targetFromImage(name, image string, params map[string]string, eventSourcesFilter, eventTypesFilter []string) error {
+func (o *createOptions) targetFromImage(name, image string, params map[string]string, eventSourcesFilter, eventTypesFilter []string) error {
 	ctx := context.Background()
 
 	et, err := o.translateEventSource(eventSourcesFilter)

--- a/cmd/create/transformation.go
+++ b/cmd/create/transformation.go
@@ -61,7 +61,7 @@ For more samples please visit:
 https://github.com/triggermesh/triggermesh/tree/main/config/samples/bumblebee`
 )
 
-func (o *CreateOptions) NewTransformationCmd() *cobra.Command {
+func (o *createOptions) NewTransformationCmd() *cobra.Command {
 	var name, target, file string
 	var eventSourcesFilter, eventTypesFilter []string
 	transformationCmd := &cobra.Command{
@@ -94,7 +94,7 @@ func (o *CreateOptions) NewTransformationCmd() *cobra.Command {
 	return transformationCmd
 }
 
-func (o *CreateOptions) transformation(name, target, file string, eventSourcesFilter, eventTypesFilter []string) error {
+func (o *createOptions) transformation(name, target, file string, eventSourcesFilter, eventTypesFilter []string) error {
 	ctx := context.Background()
 	var targetComponent triggermesh.Component
 	if target != "" {
@@ -239,7 +239,7 @@ func readInput() (string, error) {
 	return lines, scn.Err()
 }
 
-func (o *CreateOptions) lookupTarget(ctx context.Context, target string) (triggermesh.Component, error) {
+func (o *createOptions) lookupTarget(ctx context.Context, target string) (triggermesh.Component, error) {
 	targetObject, err := components.GetObject(target, o.CRD, o.Version, o.Manifest)
 	if err != nil {
 		return nil, fmt.Errorf("transformation target: %w", err)

--- a/cmd/create/trigger.go
+++ b/cmd/create/trigger.go
@@ -28,7 +28,7 @@ import (
 	tmbroker "github.com/triggermesh/tmctl/pkg/triggermesh/components/broker"
 )
 
-func (o *CreateOptions) NewTriggerCmd() *cobra.Command {
+func (o *createOptions) NewTriggerCmd() *cobra.Command {
 	var name, target string
 	var eventSourcesFilter, eventTypesFilter []string
 	triggerCmd := &cobra.Command{
@@ -61,7 +61,7 @@ func (o *CreateOptions) NewTriggerCmd() *cobra.Command {
 	return triggerCmd
 }
 
-func (o *CreateOptions) trigger(name string, eventSourcesFilter, eventTypesFilter []string, target string) error {
+func (o *createOptions) trigger(name string, eventSourcesFilter, eventTypesFilter []string, target string) error {
 	et, err := o.translateEventSource(eventSourcesFilter)
 	if err != nil {
 		return err

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -39,7 +39,7 @@ import (
 	"github.com/triggermesh/tmctl/pkg/triggermesh/crd"
 )
 
-type DeleteOptions struct {
+type deleteOptions struct {
 	ConfigBase string
 	Context    string
 	Version    string
@@ -48,7 +48,7 @@ type DeleteOptions struct {
 }
 
 func NewCmd() *cobra.Command {
-	o := &DeleteOptions{}
+	o := &deleteOptions{}
 	var broker string
 	deleteCmd := &cobra.Command{
 		Use:               "delete <component_name_1, component_name_2...> [--broker <name>]",
@@ -76,7 +76,7 @@ func NewCmd() *cobra.Command {
 	return deleteCmd
 }
 
-func (o *DeleteOptions) initialize() {
+func (o *deleteOptions) initialize() {
 	o.ConfigBase = path.Dir(viper.ConfigFileUsed())
 	o.Context = viper.GetString("context")
 	o.Version = viper.GetString("triggermesh.version")
@@ -90,7 +90,7 @@ func (o *DeleteOptions) initialize() {
 	_ = o.Manifest.Read()
 }
 
-func (o *DeleteOptions) deleteBroker(broker string) error {
+func (o *deleteOptions) deleteBroker(broker string) error {
 	oo := *o
 	oo.Context = broker
 	oo.Manifest = manifest.New(path.Join(oo.ConfigBase, broker, triggermesh.ManifestFile))
@@ -108,7 +108,7 @@ func (o *DeleteOptions) deleteBroker(broker string) error {
 	return nil
 }
 
-func (o *DeleteOptions) deleteComponents(names []string, deleteBroker bool) error {
+func (o *deleteOptions) deleteComponents(names []string, deleteBroker bool) error {
 	ctx := context.Background()
 	client, err := docker.NewClient()
 	if err != nil {
@@ -143,7 +143,7 @@ func (o *DeleteOptions) deleteComponents(names []string, deleteBroker bool) erro
 	return nil
 }
 
-func (o *DeleteOptions) deleteEverything(ctx context.Context, object kubernetes.Object, client *client.Client) {
+func (o *deleteOptions) deleteEverything(ctx context.Context, object kubernetes.Object, client *client.Client) {
 	log.Printf("Deleting %q %s", object.Metadata.Name, strings.ToLower(object.Kind))
 	if object.Kind == tmbroker.BrokerKind {
 		object.Metadata.Name = object.Metadata.Name + "-broker"
@@ -158,7 +158,7 @@ func (o *DeleteOptions) deleteEverything(ctx context.Context, object kubernetes.
 	o.cleanupSecrets(object.Metadata.Name)
 }
 
-func (o *DeleteOptions) removeObject(component string) {
+func (o *deleteOptions) removeObject(component string) {
 	for _, object := range o.Manifest.Objects {
 		if component != object.Metadata.Name {
 			continue
@@ -179,11 +179,11 @@ func (o *DeleteOptions) removeObject(component string) {
 	}
 }
 
-func (o *DeleteOptions) removeContainer(ctx context.Context, name string, client *client.Client) error {
+func (o *deleteOptions) removeContainer(ctx context.Context, name string, client *client.Client) error {
 	return docker.ForceStop(ctx, name, client)
 }
 
-func (o *DeleteOptions) cleanupTriggers(target string) {
+func (o *deleteOptions) cleanupTriggers(target string) {
 	triggers, err := tmbroker.GetTargetTriggers(target, o.Context, o.ConfigBase)
 	if err != nil {
 		return
@@ -199,7 +199,7 @@ func (o *DeleteOptions) cleanupTriggers(target string) {
 	}
 }
 
-func (o *DeleteOptions) cleanupSecrets(component string) {
+func (o *deleteOptions) cleanupSecrets(component string) {
 	for _, object := range o.Manifest.Objects {
 		if object.Metadata.Name == component+"-secret" && object.Kind == "Secret" {
 			if err := o.Manifest.Remove(object.Metadata.Name, object.Kind); err != nil {
@@ -209,7 +209,7 @@ func (o *DeleteOptions) cleanupSecrets(component string) {
 	}
 }
 
-func (o *DeleteOptions) removeExternalServices(ctx context.Context, object kubernetes.Object) error {
+func (o *deleteOptions) removeExternalServices(ctx context.Context, object kubernetes.Object) error {
 	component, err := components.GetObject(object.Metadata.Name, o.CRD, o.Version, o.Manifest)
 	if err != nil {
 		return err
@@ -229,7 +229,7 @@ func (o *DeleteOptions) removeExternalServices(ctx context.Context, object kuber
 	return r.Finalize(ctx, secretsEnv)
 }
 
-func (o *DeleteOptions) switchContext() error {
+func (o *deleteOptions) switchContext() error {
 	list, err := brokers.List(o.ConfigBase, o.Context)
 	if err != nil {
 		return fmt.Errorf("list brokers: %w", err)
@@ -243,7 +243,7 @@ func (o *DeleteOptions) switchContext() error {
 	return viper.WriteConfig()
 }
 
-func (o *DeleteOptions) deleteCompletion(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+func (o *deleteOptions) deleteCompletion(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 	if len(args) == 0 {
 		return append(completion.ListAll(o.Manifest), "--broker"),
 			cobra.ShellCompDirectiveNoFileComp

--- a/cmd/describe/describe.go
+++ b/cmd/describe/describe.go
@@ -44,7 +44,7 @@ const (
 	offlineColorCode = "\u001b[31m"
 )
 
-type DescribeOptions struct {
+type describeOptions struct {
 	ConfigBase string
 	CRD        string
 	Version    string
@@ -52,7 +52,7 @@ type DescribeOptions struct {
 }
 
 func NewCmd() *cobra.Command {
-	o := &DescribeOptions{}
+	o := &describeOptions{}
 	return &cobra.Command{
 		Use:   "describe [broker]",
 		Short: "Show broker status",
@@ -78,7 +78,7 @@ func NewCmd() *cobra.Command {
 	}
 }
 
-func (o DescribeOptions) describe(b string) error {
+func (o *describeOptions) describe(b string) error {
 	broker := tabwriter.NewWriter(os.Stdout, 10, 5, 5, ' ', 0)
 	triggers := tabwriter.NewWriter(os.Stdout, 10, 5, 5, ' ', 0)
 	producers := tabwriter.NewWriter(os.Stdout, 10, 5, 5, ' ', 0)

--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -17,9 +17,12 @@ limitations under the License.
 package dump
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -28,22 +31,27 @@ import (
 	"github.com/triggermesh/tmctl/pkg/kubernetes"
 	"github.com/triggermesh/tmctl/pkg/manifest"
 	"github.com/triggermesh/tmctl/pkg/triggermesh"
+	"github.com/triggermesh/tmctl/pkg/triggermesh/components"
 	tmbroker "github.com/triggermesh/tmctl/pkg/triggermesh/components/broker"
+	"github.com/triggermesh/tmctl/pkg/triggermesh/crd"
 )
 
-type DumpOptions struct {
+type dumpOptions struct {
 	Format   string
 	Context  string
+	Version  string
+	CRD      string
 	Manifest *manifest.Manifest
 }
 
 func NewCmd() *cobra.Command {
-	o := &DumpOptions{}
+	o := &dumpOptions{}
 	knativeEventing := false
 	dumpCmd := &cobra.Command{
 		Use:   "dump [broker]",
 		Short: "Generate Kubernetes manifest",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			o.Version = viper.GetString("triggermesh.version")
 			broker := viper.GetString("context")
 			if len(args) == 1 {
 				broker = args[0]
@@ -51,6 +59,9 @@ func NewCmd() *cobra.Command {
 			o.Context = broker
 			o.Manifest = manifest.New(path.Join(path.Dir(viper.ConfigFileUsed()), broker, triggermesh.ManifestFile))
 			cobra.CheckErr(o.Manifest.Read())
+			crds, err := crd.Fetch(path.Dir(viper.ConfigFileUsed()), o.Version)
+			cobra.CheckErr(err)
+			o.CRD = crds
 			return o.dump(knativeEventing)
 		},
 	}
@@ -59,37 +70,48 @@ func NewCmd() *cobra.Command {
 	return dumpCmd
 }
 
-func (o *DumpOptions) dump(useKnativeEventing bool) error {
-	if useKnativeEventing {
-		for i, object := range o.Manifest.Objects {
-			o.Manifest.Objects[i] = o.knativeEventingTranformation(object)
+func (o *dumpOptions) dump(useKnativeEventing bool) error {
+	var externalReconcilable []string
+	for _, object := range o.Manifest.Objects {
+		if component, err := components.GetObject(object.Metadata.Name, o.CRD, o.Version, o.Manifest); err == nil {
+			if _, ok := component.(triggermesh.Reconcilable); ok {
+				if container, ok := component.(triggermesh.Runnable); ok {
+					if _, err := container.Info(context.Background()); err == nil {
+						externalReconcilable = append(externalReconcilable, component.GetName())
+					}
+				}
+			}
 		}
-	}
-	switch o.Format {
-	case "json":
-		for _, object := range o.Manifest.Objects {
+		if useKnativeEventing {
+			object = o.knativeEventingTransformation(object)
+		}
+		switch o.Format {
+		case "json":
 			jsn, err := json.MarshalIndent(object, "", "  ")
 			if err != nil {
 				return err
 			}
 			fmt.Println(string(jsn))
-		}
-	case "yaml":
-		for _, object := range o.Manifest.Objects {
+		case "yaml":
 			yml, err := yaml.Marshal(object)
 			if err != nil {
 				return err
 			}
 			fmt.Println("---")
 			fmt.Println(string(yml))
+		default:
+			return fmt.Errorf("format %q is not supported", o.Format)
 		}
-	default:
-		return fmt.Errorf("format %q is not supported", o.Format)
+	}
+	if len(externalReconcilable) != 0 {
+		fmt.Fprintf(os.Stderr, "\nWARNING: manifest contains running components that use external shared resources to produce events.\n"+
+			"It is strongly recommended to stop the broker before deploying integration in the cluster to avoid events read race conditions.\n"+
+			"Components with external resources: %s\n", strings.Join(externalReconcilable, ", "))
 	}
 	return nil
 }
 
-func (o *DumpOptions) knativeEventingTranformation(object kubernetes.Object) kubernetes.Object {
+func (o *dumpOptions) knativeEventingTransformation(object kubernetes.Object) kubernetes.Object {
 	switch object.APIVersion {
 	case tmbroker.APIVersion:
 		switch object.Kind {

--- a/cmd/sendevent/sendevent.go
+++ b/cmd/sendevent/sendevent.go
@@ -39,7 +39,7 @@ const (
 	defaultEventSource = "triggermesh-cli"
 )
 
-type SendOptions struct {
+type sendOptions struct {
 	Context   string
 	ConfigDir string
 	Version   string
@@ -48,7 +48,7 @@ type SendOptions struct {
 }
 
 func NewCmd() *cobra.Command {
-	o := &SendOptions{}
+	o := &sendOptions{}
 	var eventType, target string
 	sendCmd := &cobra.Command{
 		Use:   "send-event [--eventType <type>][--destination <name>] <data> ",
@@ -74,7 +74,7 @@ func NewCmd() *cobra.Command {
 	return sendCmd
 }
 
-func (o *SendOptions) initialize() {
+func (o *sendOptions) initialize() {
 	o.ConfigDir = path.Dir(viper.ConfigFileUsed())
 	o.Context = viper.GetString("context")
 	o.Version = viper.GetString("triggermesh.version")
@@ -88,7 +88,7 @@ func (o *SendOptions) initialize() {
 	_ = o.Manifest.Read()
 }
 
-func (o *SendOptions) send(eventType, target, data string) error {
+func (o *sendOptions) send(eventType, target, data string) error {
 	ctx := context.Background()
 	component, err := components.GetObject(target, o.CRD, o.Version, o.Manifest)
 	if err != nil {

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -33,7 +33,7 @@ import (
 	"github.com/triggermesh/tmctl/pkg/triggermesh/crd"
 )
 
-type StartOptions struct {
+type startOptions struct {
 	ConfigBase string
 	Context    string
 	Version    string
@@ -43,7 +43,7 @@ type StartOptions struct {
 }
 
 func NewCmd() *cobra.Command {
-	o := &StartOptions{}
+	o := &startOptions{}
 	createCmd := &cobra.Command{
 		Use:   "start [broker]",
 		Short: "Starts TriggerMesh components",
@@ -66,7 +66,7 @@ func NewCmd() *cobra.Command {
 	return createCmd
 }
 
-func (o *StartOptions) initialize() {
+func (o *startOptions) initialize() {
 	o.ConfigBase = path.Dir(viper.ConfigFileUsed())
 	o.Context = viper.GetString("context")
 	o.Version = viper.GetString("triggermesh.version")
@@ -76,7 +76,7 @@ func (o *StartOptions) initialize() {
 	o.CRD = crds
 }
 
-func (o *StartOptions) start(broker string) error {
+func (o *startOptions) start(broker string) error {
 	ctx := context.Background()
 	var brokerPort string
 	// start eventing first

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -31,13 +31,13 @@ import (
 	tmbroker "github.com/triggermesh/tmctl/pkg/triggermesh/components/broker"
 )
 
-type StopOptions struct {
+type stopOptions struct {
 	ConfigBase string
 	Manifest   *manifest.Manifest
 }
 
 func NewCmd() *cobra.Command {
-	o := &StopOptions{}
+	o := &stopOptions{}
 	stopCmd := &cobra.Command{
 		Use:       "stop [broker]",
 		Short:     "Stops TriggerMesh components",
@@ -53,11 +53,10 @@ func NewCmd() *cobra.Command {
 			return o.stop(broker)
 		},
 	}
-
 	return stopCmd
 }
 
-func (o *StopOptions) stop(broker string) error {
+func (o *stopOptions) stop(broker string) error {
 	ctx := context.Background()
 	client, err := docker.NewClient()
 	if err != nil {

--- a/cmd/watch/watch.go
+++ b/cmd/watch/watch.go
@@ -35,7 +35,7 @@ import (
 	"github.com/triggermesh/tmctl/pkg/wiretap"
 )
 
-type WatchOptions struct {
+type watchOptions struct {
 	ConfigDir  string
 	EventTypes string
 	Source     string
@@ -49,7 +49,7 @@ type brokerLog struct {
 }
 
 func NewCmd() *cobra.Command {
-	o := WatchOptions{}
+	o := watchOptions{}
 	watchCmd := &cobra.Command{
 		Use:   "watch [broker]",
 		Short: "Watch events flowing through the broker",
@@ -64,13 +64,11 @@ func NewCmd() *cobra.Command {
 			return o.watch(viper.GetString("context"))
 		},
 	}
-
 	watchCmd.Flags().StringVarP(&o.EventTypes, "event-types", "e", "", "Filter events based on type attribute")
-
 	return watchCmd
 }
 
-func (o *WatchOptions) watch(broker string) error {
+func (o *watchOptions) watch(broker string) error {
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 


### PR DESCRIPTION
The `dump` command checks if the manifest contains the components with external resources and prints the warning message to help avoid race conditions.

Additionally, internal CLI structures unexported to improve linting situation. 