### PR TITLE
Broker parameters in CLI config

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -37,8 +37,6 @@ import (
 	"github.com/triggermesh/tmctl/pkg/triggermesh"
 )
 
-const defaultBroker = ""
-
 func NewRootCommand(ver, commit string) *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "tmctl",
@@ -51,8 +49,8 @@ Find more information at: https://docs.triggermesh.io`,
 
 	cobra.OnInitialize(initConfig)
 
-	rootCmd.PersistentFlags().String("version", triggermesh.DefaultVersion, "TriggerMesh components version.")
-	rootCmd.PersistentFlags().String("broker", defaultBroker, "Optional broker name.")
+	rootCmd.PersistentFlags().String("version", "", "TriggerMesh components version.")
+	rootCmd.PersistentFlags().String("broker", "", "Optional broker name.")
 	// rootCmd.PersistentFlags().MarkHidden("broker")
 
 	cobra.CheckErr(viper.BindPFlag("context", rootCmd.PersistentFlags().Lookup("broker")))
@@ -94,8 +92,9 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
 			cobra.CheckErr(os.MkdirAll(configHome, os.ModePerm))
-			viper.SetDefault("context", defaultBroker)
-			viper.SetDefault("triggermesh.version", triggermesh.DefaultVersion)
+			for k, v := range triggermesh.DefaultConfig {
+				viper.SetDefault(k, v)
+			}
 			cobra.CheckErr(viper.SafeWriteConfig())
 			cobra.CheckErr(viper.ReadInConfig())
 		} else {

--- a/pkg/triggermesh/components/broker/broker.go
+++ b/pkg/triggermesh/components/broker/broker.go
@@ -25,6 +25,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/spf13/viper"
 	"github.com/triggermesh/tmctl/pkg/docker"
 	"github.com/triggermesh/tmctl/pkg/kubernetes"
 	"github.com/triggermesh/tmctl/pkg/triggermesh"
@@ -43,7 +44,6 @@ const (
 	APIVersion  = "eventing.triggermesh.io/v1alpha1"
 
 	brokerConfigFile = "broker.conf"
-	image            = "gcr.io/triggermesh/memory-broker:dev"
 )
 
 type Broker struct {
@@ -81,7 +81,7 @@ func (b *Broker) asContainer(additionalEnvs map[string]string) (*docker.Containe
 	if err != nil {
 		return nil, fmt.Errorf("creating object: %w", err)
 	}
-	co, ho, err := adapter.RuntimeParams(o, image, additionalEnvs)
+	co, ho, err := adapter.RuntimeParams(o, viper.GetString("triggermesh.broker.image"), additionalEnvs)
 	if err != nil {
 		return nil, fmt.Errorf("creating adapter params: %w", err)
 	}
@@ -89,9 +89,9 @@ func (b *Broker) asContainer(additionalEnvs map[string]string) (*docker.Containe
 		"/memory-broker",
 		"start",
 		"--memory.buffer-size",
-		"100",
+		viper.GetString("triggermesh.broker.memory.buffer-size"),
 		"--memory.produce-timeout",
-		"1s",
+		viper.GetString("triggermesh.broker.memory.produce-timeout"),
 		"--broker-config-path",
 		"/etc/triggermesh/broker.conf",
 	}))
@@ -105,7 +105,7 @@ func (b *Broker) asContainer(additionalEnvs map[string]string) (*docker.Containe
 	}
 	return &docker.Container{
 		Name:                   name,
-		Image:                  image,
+		Image:                  viper.GetString("triggermesh.broker.image"),
 		CreateHostOptions:      ho,
 		CreateContainerOptions: co,
 	}, nil

--- a/pkg/triggermesh/constants.go
+++ b/pkg/triggermesh/constants.go
@@ -16,13 +16,54 @@ limitations under the License.
 
 package triggermesh
 
-// TriggerMesh constant values used as default paths, config names, etc.
-const (
-	Namespace    = "local"
-	ManifestFile = "manifest.yaml"
+import (
+	"encoding/json"
+	"net/http"
+)
 
+var DefaultConfig = map[string]interface{}{
+	"context":                                   defaultContext,
+	"triggermesh.version":                       latestOrDefault(defaultVersion),
+	"triggermesh.broker.image":                  MemoryBrokerImage,
+	"triggermesh.broker.memory.buffer-size":     MemoryBrokerBufferSize,
+	"triggermesh.broker.memory.produce-timeout": MemoryBrokerProduceTimeout,
+}
+
+// TriggerMesh constant values used as default paths, configs, etc.
+const (
 	ConfigFile = "config.yaml"
 	ConfigDir  = ".triggermesh/cli"
 
-	DefaultVersion = "v1.21.1"
+	defaultContext = ""
+	Namespace      = "local"
+	ManifestFile   = "manifest.yaml"
+
+	// version default parameters
+	ghLatestRelease = "https://api.github.com/repos/triggermesh/triggermesh/releases/latest"
+	defaultVersion  = "v1.21.1"
+
+	// broker default parameters
+	MemoryBrokerImage          = "gcr.io/triggermesh/memory-broker:dev"
+	MemoryBrokerBufferSize     = "100"
+	MemoryBrokerProduceTimeout = "1s"
 )
+
+type release struct {
+	TagName string `json:"tag_name"`
+}
+
+func latestOrDefault(defaultVersion string) string {
+	r, err := http.Get(ghLatestRelease)
+	if err != nil {
+		return defaultVersion
+	}
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusOK {
+		return defaultVersion
+	}
+	var j release
+	if err := json.NewDecoder(r.Body).Decode(&j); err != nil {
+		return defaultVersion
+	}
+	return j.TagName
+}

--- a/pkg/triggermesh/crd/crd.go
+++ b/pkg/triggermesh/crd/crd.go
@@ -17,7 +17,6 @@ limitations under the License.
 package crd
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -32,8 +31,7 @@ import (
 )
 
 const (
-	ghLatestRelease = "https://api.github.com/repos/triggermesh/triggermesh/releases/latest"
-	crdsURL         = "https://github.com/triggermesh/triggermesh/releases/download/$VERSION/triggermesh-crds.yaml"
+	crdsURL = "https://github.com/triggermesh/triggermesh/releases/download/$VERSION/triggermesh-crds.yaml"
 )
 
 type CRD struct {
@@ -76,30 +74,8 @@ type EventTypes []struct {
 	Type string `json:"type"`
 }
 
-type release struct {
-	TagName string `json:"tag_name"`
-}
-
-func latest() (string, error) {
-	r, err := http.Get(ghLatestRelease)
-	if err != nil {
-		return "", fmt.Errorf("latest release request: %w", err)
-	}
-	defer r.Body.Close()
-	if r.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("latest release status: %w", err)
-	}
-	var j release
-	return j.TagName, json.NewDecoder(r.Body).Decode(&j)
-}
-
 func Fetch(configDir, version string) (string, error) {
 	var err error
-	if version == "latest" {
-		if version, err = latest(); err != nil {
-			return "", fmt.Errorf("cannot fetch \"latest\" version: %w", err)
-		}
-	}
 	url := strings.ReplaceAll(crdsURL, "$VERSION", version)
 	crdDir := path.Join(configDir, "crd", version)
 	if err := os.MkdirAll(crdDir, os.ModePerm); err != nil {


### PR DESCRIPTION
1. Config default values and structure moved to `pkg/triggermesh` package,
2. Broker default values exposed in CLI's config file,
3. Components' default version is set to either latest available at the moment of the CLI's first start or to the hardcoded default. Overridable through the config file or global `--version` parameter.