### PR TITLE
Broker config for Windows. Event type flag consistent across commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -19,6 +19,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -105,6 +106,11 @@ func initConfig() {
 			cobra.CheckErr(os.MkdirAll(configHome, os.ModePerm))
 			for k, v := range triggermesh.DefaultConfig {
 				viper.SetDefault(k, v)
+			}
+			if runtime.GOOS == "windows" {
+				for k, v := range triggermesh.WindowsConfig {
+					viper.SetDefault(k, v)
+				}
 			}
 			cobra.CheckErr(viper.SafeWriteConfig())
 			cobra.CheckErr(viper.ReadInConfig())

--- a/cmd/create/completion.go
+++ b/cmd/create/completion.go
@@ -116,13 +116,13 @@ func (o *createOptions) targetsCompletion(cmd *cobra.Command, args []string, toC
 		return completion.ListSources(o.Manifest), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
 	}
 
-	if lastParam(args) == "--event-types" && strings.HasSuffix(args[len(args)-1], ",") {
+	if lastParam(args) == "--eventTypes" && strings.HasSuffix(args[len(args)-1], ",") {
 		return completion.ListEventTypes(o.Manifest, o.CRD, o.Version),
 			cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
 	}
 
 	if toComplete == "--source" ||
-		toComplete == "--event-types" ||
+		toComplete == "--eventTypes" ||
 		toComplete == "--name" ||
 		toComplete == "--from-image" {
 		return []string{toComplete}, cobra.ShellCompDirectiveNoFileComp
@@ -130,7 +130,7 @@ func (o *createOptions) targetsCompletion(cmd *cobra.Command, args []string, toC
 	switch args[len(args)-1] {
 	case "--source":
 		return completion.ListSources(o.Manifest), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
-	case "--event-types":
+	case "--eventTypes":
 		return completion.ListEventTypes(o.Manifest, o.CRD, o.Version),
 			cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
 	case "--broker":
@@ -184,7 +184,7 @@ func (o *createOptions) targetsCompletion(cmd *cobra.Command, args []string, toC
 	}
 	return append(spec,
 		"--source\tEvent source name.",
-		"--event-types\tEvent types filter.",
+		"--eventTypes\tEvent types filter.",
 		"--name\tOptional component name.",
 	), cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
 }

--- a/cmd/create/source.go
+++ b/cmd/create/source.go
@@ -37,7 +37,7 @@ import (
 func (o *createOptions) newSourceCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "source [kind]/[--from-image <image>][--name <name>]",
-		Short: "Create TriggerMesh source",
+		Short: "Create TriggerMesh source. More information at https://docs.triggermesh.io",
 		Example: `tmctl create source httppoller \
 	--endpoint https://www.example.com \
 	--eventType sample-event \

--- a/cmd/create/target.go
+++ b/cmd/create/target.go
@@ -38,8 +38,8 @@ import (
 
 func (o *createOptions) newTargetCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "target [kind]/[--from-image <image>][--name <name>][--source <name>...][--event-types <type>...]",
-		Short: "Create TriggerMesh target",
+		Use:   "target [kind]/[--from-image <image>][--name <name>][--source <name>...][--eventTypes <type>...]",
+		Short: "Create TriggerMesh target. More information at https://docs.triggermesh.io",
 		Example: `tmctl create target http \
 	--endpoint https://image-charts.com \
 	--method GET \
@@ -77,12 +77,12 @@ func (o *createOptions) newTargetCmd() *cobra.Command {
 				}
 				delete(params, "source")
 			}
-			if tf, exists := params["event-types"]; exists {
+			if tf, exists := params["eventTypes"]; exists {
 				eventTypesFilter = strings.Split(tf, ",")
 				if len(eventTypesFilter) == 1 {
 					eventTypesFilter = strings.Split(tf, " ")
 				}
-				delete(params, "event-types")
+				delete(params, "eventTypes")
 			}
 			if _, readDisabled := params["disable-file-args"]; !readDisabled {
 				for key, value := range params {

--- a/cmd/create/transformation.go
+++ b/cmd/create/transformation.go
@@ -65,7 +65,7 @@ func (o *createOptions) newTransformationCmd() *cobra.Command {
 	var name, target, file string
 	var eventSourcesFilter, eventTypesFilter []string
 	transformationCmd := &cobra.Command{
-		Use:   "transformation [--target <name>][--source <name>...][--event-types <type>...][--from <path>]",
+		Use:   "transformation [--target <name>][--source <name>...][--eventTypes <type>...][--from <path>]",
 		Short: "Create TriggerMesh transformation. More information at https://docs.triggermesh.io/transformation/jsontransformation/",
 		Example: `tmctl create transformation <<EOF
   data:
@@ -74,7 +74,7 @@ func (o *createOptions) newTransformationCmd() *cobra.Command {
     - key: new-field
       value: hello from Transformation!
 EOF`,
-		ValidArgs: []string{"--name", "--target", "--source", "--event-types", "--from"},
+		ValidArgs: []string{"--name", "--target", "--source", "--eventTypes", "--from"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cobra.CheckErr(o.Manifest.Read())
 			return o.transformation(name, target, file, eventSourcesFilter, eventTypesFilter)
@@ -84,7 +84,7 @@ EOF`,
 	transformationCmd.Flags().StringVarP(&file, "from", "f", "", "Transformation specification file")
 	transformationCmd.Flags().StringVar(&target, "target", "", "Target name")
 	transformationCmd.Flags().StringSliceVar(&eventSourcesFilter, "source", []string{}, "Sources component names")
-	transformationCmd.Flags().StringSliceVar(&eventTypesFilter, "event-types", []string{}, "Event types filter")
+	transformationCmd.Flags().StringSliceVar(&eventTypesFilter, "eventTypes", []string{}, "Event types filter")
 
 	cobra.CheckErr(transformationCmd.RegisterFlagCompletionFunc("name", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return []string{}, cobra.ShellCompDirectiveNoFileComp
@@ -92,7 +92,7 @@ EOF`,
 	cobra.CheckErr(transformationCmd.RegisterFlagCompletionFunc("source", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return completion.ListSources(o.Manifest), cobra.ShellCompDirectiveNoFileComp
 	}))
-	cobra.CheckErr(transformationCmd.RegisterFlagCompletionFunc("event-types", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	cobra.CheckErr(transformationCmd.RegisterFlagCompletionFunc("eventTypes", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return completion.ListEventTypes(o.Manifest, o.CRD, o.Version), cobra.ShellCompDirectiveNoFileComp
 	}))
 	cobra.CheckErr(transformationCmd.RegisterFlagCompletionFunc("target", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/create/trigger.go
+++ b/cmd/create/trigger.go
@@ -32,10 +32,10 @@ func (o *createOptions) newTriggerCmd() *cobra.Command {
 	var name, target string
 	var eventSourcesFilter, eventTypesFilter []string
 	triggerCmd := &cobra.Command{
-		Use:       "trigger --target <name> [--source <name>...][--event-types <type>...]",
+		Use:       "trigger --target <name> [--source <name>...][--eventTypes <type>...]",
 		Short:     "Create TriggerMesh trigger. More information at https://docs.triggermesh.io/brokers/triggers/",
 		Example:   "tmctl create trigger --target sockeye --source foo-httppollersource",
-		ValidArgs: []string{"--target", "--name", "--source", "--event-types"},
+		ValidArgs: []string{"--target", "--name", "--source", "--eventTypes"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cobra.CheckErr(o.Manifest.Read())
 			return o.trigger(name, eventSourcesFilter, eventTypesFilter, target)
@@ -44,7 +44,7 @@ func (o *createOptions) newTriggerCmd() *cobra.Command {
 	triggerCmd.Flags().StringVar(&name, "name", "", "Trigger name")
 	triggerCmd.Flags().StringVar(&target, "target", "", "Target name")
 	triggerCmd.Flags().StringSliceVar(&eventSourcesFilter, "source", []string{}, "Event sources filter")
-	triggerCmd.Flags().StringSliceVar(&eventTypesFilter, "event-types", []string{}, "Event types filter")
+	triggerCmd.Flags().StringSliceVar(&eventTypesFilter, "eventTypes", []string{}, "Event types filter")
 	cobra.CheckErr(triggerCmd.MarkFlagRequired("target"))
 
 	cobra.CheckErr(triggerCmd.RegisterFlagCompletionFunc("name", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
@@ -53,7 +53,7 @@ func (o *createOptions) newTriggerCmd() *cobra.Command {
 	cobra.CheckErr(triggerCmd.RegisterFlagCompletionFunc("source", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return completion.ListSources(o.Manifest), cobra.ShellCompDirectiveNoFileComp
 	}))
-	cobra.CheckErr(triggerCmd.RegisterFlagCompletionFunc("event-types", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	cobra.CheckErr(triggerCmd.RegisterFlagCompletionFunc("eventTypes", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return completion.ListEventTypes(o.Manifest, o.CRD, o.Version), cobra.ShellCompDirectiveNoFileComp
 	}))
 	cobra.CheckErr(triggerCmd.RegisterFlagCompletionFunc("target", func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/watch/watch.go
+++ b/cmd/watch/watch.go
@@ -65,7 +65,7 @@ func NewCmd() *cobra.Command {
 			return o.watch(viper.GetString("context"))
 		},
 	}
-	watchCmd.Flags().StringVarP(&o.EventTypes, "event-types", "e", "", "Filter events based on type attribute")
+	watchCmd.Flags().StringVarP(&o.EventTypes, "eventTypes", "e", "", "Filter events based on type attribute")
 	return watchCmd
 }
 

--- a/docs/tmctl_create.md
+++ b/docs/tmctl_create.md
@@ -19,8 +19,8 @@ Create TriggerMesh component
 
 * [tmctl](tmctl.md)	 - A command line interface to build event-driven applications
 * [tmctl create broker](tmctl_create_broker.md)	 - Create TriggerMesh Broker. More information at https://docs.triggermesh.io/brokers/
-* [tmctl create source](tmctl_create_source.md)	 - Create TriggerMesh source
-* [tmctl create target](tmctl_create_target.md)	 - Create TriggerMesh target
+* [tmctl create source](tmctl_create_source.md)	 - Create TriggerMesh source. More information at https://docs.triggermesh.io
+* [tmctl create target](tmctl_create_target.md)	 - Create TriggerMesh target. More information at https://docs.triggermesh.io
 * [tmctl create transformation](tmctl_create_transformation.md)	 - Create TriggerMesh transformation. More information at https://docs.triggermesh.io/transformation/jsontransformation/
 * [tmctl create trigger](tmctl_create_trigger.md)	 - Create TriggerMesh trigger. More information at https://docs.triggermesh.io/brokers/triggers/
 

--- a/docs/tmctl_create_source.md
+++ b/docs/tmctl_create_source.md
@@ -1,6 +1,6 @@
 ## tmctl create source
 
-Create TriggerMesh source
+Create TriggerMesh source. More information at https://docs.triggermesh.io
 
 ```
 tmctl create source [kind]/[--from-image <image>][--name <name>] [flags]

--- a/docs/tmctl_create_target.md
+++ b/docs/tmctl_create_target.md
@@ -1,9 +1,9 @@
 ## tmctl create target
 
-Create TriggerMesh target
+Create TriggerMesh target. More information at https://docs.triggermesh.io
 
 ```
-tmctl create target [kind]/[--from-image <image>][--name <name>][--source <name>...][--event-types <type>...] [flags]
+tmctl create target [kind]/[--from-image <image>][--name <name>][--source <name>...][--eventTypes <type>...] [flags]
 ```
 
 ### Examples

--- a/docs/tmctl_create_transformation.md
+++ b/docs/tmctl_create_transformation.md
@@ -3,7 +3,7 @@
 Create TriggerMesh transformation. More information at https://docs.triggermesh.io/transformation/jsontransformation/
 
 ```
-tmctl create transformation [--target <name>][--source <name>...][--event-types <type>...][--from <path>] [flags]
+tmctl create transformation [--target <name>][--source <name>...][--eventTypes <type>...][--from <path>] [flags]
 ```
 
 ### Examples
@@ -21,12 +21,12 @@ EOF
 ### Options
 
 ```
-      --event-types strings   Event types filter
-  -f, --from string           Transformation specification file
-  -h, --help                  help for transformation
-      --name string           Transformation name
-      --source strings        Sources component names
-      --target string         Target name
+      --eventTypes strings   Event types filter
+  -f, --from string          Transformation specification file
+  -h, --help                 help for transformation
+      --name string          Transformation name
+      --source strings       Sources component names
+      --target string        Target name
 ```
 
 ### Options inherited from parent commands

--- a/docs/tmctl_create_trigger.md
+++ b/docs/tmctl_create_trigger.md
@@ -3,7 +3,7 @@
 Create TriggerMesh trigger. More information at https://docs.triggermesh.io/brokers/triggers/
 
 ```
-tmctl create trigger --target <name> [--source <name>...][--event-types <type>...] [flags]
+tmctl create trigger --target <name> [--source <name>...][--eventTypes <type>...] [flags]
 ```
 
 ### Examples
@@ -15,11 +15,11 @@ tmctl create trigger --target sockeye --source foo-httppollersource
 ### Options
 
 ```
-      --event-types strings   Event types filter
-  -h, --help                  help for trigger
-      --name string           Trigger name
-      --source strings        Event sources filter
-      --target string         Target name
+      --eventTypes strings   Event types filter
+  -h, --help                 help for trigger
+      --name string          Trigger name
+      --source strings       Event sources filter
+      --target string        Target name
 ```
 
 ### Options inherited from parent commands

--- a/docs/tmctl_watch.md
+++ b/docs/tmctl_watch.md
@@ -15,8 +15,8 @@ tmctl watch
 ### Options
 
 ```
-  -e, --event-types string   Filter events based on type attribute
-  -h, --help                 help for watch
+  -e, --eventTypes string   Filter events based on type attribute
+  -h, --help                help for watch
 ```
 
 ### Options inherited from parent commands

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -49,7 +49,7 @@ func PrintStatus(kind string, object triggermesh.Component, eventSourcesFilter, 
 		}
 		result = fmt.Sprintf("%s%s\n%s", successColorCode, result, defaultColorCode)
 		// result = fmt.Sprintf("%s\nNext steps:", result)
-		// result = fmt.Sprintf("%s\n\ttmctl create target <kind> --source %s [--event-types <types>]\t - create target that will consume events from this source", result, object.GetName())
+		// result = fmt.Sprintf("%s\n\ttmctl create target <kind> --source %s [--eventTypes <types>]\t - create target that will consume events from this source", result, object.GetName())
 		// result = fmt.Sprintf("%s\n\ttmctl watch\t\t\t\t\t\t\t\t\t - show events flowing through the broker in the real time", result)
 	case "consumer":
 		et, _ := object.(triggermesh.Consumer).ConsumedEventTypes()

--- a/pkg/triggermesh/components/broker/broker.go
+++ b/pkg/triggermesh/components/broker/broker.go
@@ -85,7 +85,8 @@ func (b *Broker) asContainer(additionalEnvs map[string]string) (*docker.Containe
 	if err != nil {
 		return nil, fmt.Errorf("creating adapter params: %w", err)
 	}
-	co = append(co, docker.WithEntrypoint([]string{
+
+	entrypoint := []string{
 		"/memory-broker",
 		"start",
 		"--memory.buffer-size",
@@ -94,7 +95,12 @@ func (b *Broker) asContainer(additionalEnvs map[string]string) (*docker.Containe
 		viper.GetString("triggermesh.broker.memory.produce-timeout"),
 		"--broker-config-path",
 		"/etc/triggermesh/broker.conf",
-	}))
+	}
+	pollingPeriod := viper.GetString("triggermesh.broker.memory.config-polling-period")
+	if pollingPeriod != "" {
+		entrypoint = append(entrypoint, []string{"--config-polling-period", pollingPeriod}...)
+	}
+	co = append(co, docker.WithEntrypoint(entrypoint))
 
 	bind := fmt.Sprintf("%s:/etc/triggermesh/broker.conf", b.ConfigFile)
 	ho = append(ho, docker.WithVolumeBind(bind))

--- a/pkg/triggermesh/constants.go
+++ b/pkg/triggermesh/constants.go
@@ -29,6 +29,10 @@ var DefaultConfig = map[string]interface{}{
 	"triggermesh.broker.memory.produce-timeout": MemoryBrokerProduceTimeout,
 }
 
+var WindowsConfig = map[string]interface{}{
+	"triggermesh.broker.memory.config-polling-period": MemoryBrokerConfigPollingPeriod,
+}
+
 // TriggerMesh constant values used as default paths, configs, etc.
 const (
 	ConfigFile = "config.yaml"
@@ -50,6 +54,9 @@ const (
 	MemoryBrokerImage          = "gcr.io/triggermesh/memory-broker:latest"
 	MemoryBrokerBufferSize     = "100"
 	MemoryBrokerProduceTimeout = "1s"
+
+	// Broker config polling period. On Windows only.
+	MemoryBrokerConfigPollingPeriod = "PT2S"
 )
 
 type release struct {


### PR DESCRIPTION
This PR contains two fixes that should be in the 1.0.0 version:

1. On the Windows OS, CLI's default config will contain an additional parameter that switches Broker to config polling mode. 
2. `--event-types` flag across all commands replaced with `--eventTypes` for consistency.
