### PR TITLE
Fix EventHubs old names

### DIFF
--- a/pkg/triggermesh/adapter/adapter.go
+++ b/pkg/triggermesh/adapter/adapter.go
@@ -45,7 +45,7 @@ func Image(object unstructured.Unstructured, version string) string {
 		"AzureServiceBusQueueSource":
 		return fmt.Sprintf("%s/azureservicebussource-adapter:%s", registry, version)
 	case "AzureBlobStorageSource":
-		return fmt.Sprintf("%s/azureeventhubsource-adapter:%s", registry, version)
+		return fmt.Sprintf("%s/azureeventhubssource-adapter:%s", registry, version)
 	case "GoogleCloudAuditLogsSource",
 		"GoogleCloudStorageSource",
 		"GoogleCloudSourceRepositoriesSource":

--- a/pkg/triggermesh/adapter/ce/sources.go
+++ b/pkg/triggermesh/adapter/ce/sources.go
@@ -160,7 +160,7 @@ func sources(object unstructured.Unstructured) (EventAttributes, error) {
 			ProducedEventTypes:  o.GetEventTypes(),
 			ProducedEventSource: o.AsEventSource(),
 		}, nil
-	case "AzureEventHubSource":
+	case "AzureEventHubsSource":
 		var o *sourcesv1alpha1.AzureEventHubsSource
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
 			return EventAttributes{}, err


### PR DESCRIPTION
triggermesh/triggermesh v1.22.0 doesn't have `azureeventhubsource` since [this](triggermesh/triggermesh#1225) PR was merged. CLI has a couple of places with hardcoded names that needs to be updated. 
Resolves #115, resolves #185, resolves #186