### PR TITLE
Logs interaction improvements

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/triggermesh/tmctl/cmd/delete"
 	"github.com/triggermesh/tmctl/cmd/describe"
 	"github.com/triggermesh/tmctl/cmd/dump"
+	"github.com/triggermesh/tmctl/cmd/logs"
 	"github.com/triggermesh/tmctl/cmd/sendevent"
 	"github.com/triggermesh/tmctl/cmd/start"
 	"github.com/triggermesh/tmctl/cmd/stop"
@@ -66,6 +67,7 @@ Find more information at: https://docs.triggermesh.io`,
 	rootCmd.AddCommand(delete.NewCmd())
 	rootCmd.AddCommand(describe.NewCmd())
 	rootCmd.AddCommand(dump.NewCmd())
+	rootCmd.AddCommand(logs.NewCmd())
 	rootCmd.AddCommand(sendevent.NewCmd())
 	rootCmd.AddCommand(start.NewCmd())
 	rootCmd.AddCommand(stop.NewCmd())

--- a/cmd/describe/describe.go
+++ b/cmd/describe/describe.go
@@ -41,7 +41,7 @@ import (
 const (
 	successColorCode = "\033[92m"
 	defaultColorCode = "\033[39m"
-	offlineColorCode = "\u001b[31m"
+	offlineColorCode = "\033[31m"
 )
 
 type describeOptions struct {

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logs
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/triggermesh/tmctl/pkg/completion"
+	"github.com/triggermesh/tmctl/pkg/manifest"
+	"github.com/triggermesh/tmctl/pkg/triggermesh"
+	"github.com/triggermesh/tmctl/pkg/triggermesh/components"
+	"github.com/triggermesh/tmctl/pkg/triggermesh/crd"
+)
+
+const defaultColorCode = "\033[39m"
+
+var colors = []string{
+	"\033[31m", // red
+	"\033[32m", // green
+	"\033[33m", // yellow
+	"\033[34m", // blue
+	"\033[35m", // magent
+	"\033[36m", // cyan
+}
+
+var defaultLogPeriod = 24 * time.Hour
+
+type logsOptions struct {
+	ConfigBase string
+	Context    string
+	CRD        string
+	Version    string
+	Manifest   *manifest.Manifest
+}
+
+func NewCmd() *cobra.Command {
+	o := &logsOptions{}
+	var follow bool
+	logsCmd := &cobra.Command{
+		Use:     "logs [name]",
+		Short:   "Display components logs",
+		Example: "tmctl logs",
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return completion.ListAll(o.Manifest), cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.logs(args, follow)
+		},
+	}
+	cobra.OnInitialize(o.initialize)
+
+	logsCmd.Flags().BoolVarP(&follow, "follow", "f", false, "Follow logs output")
+	return logsCmd
+}
+
+func (o *logsOptions) initialize() {
+	o.ConfigBase = filepath.Dir(viper.ConfigFileUsed())
+	o.Context = viper.GetString("context")
+	o.Version = viper.GetString("triggermesh.version")
+	o.Manifest = manifest.New(filepath.Join(o.ConfigBase, o.Context, triggermesh.ManifestFile))
+	crds, err := crd.Fetch(o.ConfigBase, o.Version)
+	cobra.CheckErr(err)
+	o.CRD = crds
+
+	// try to read manifest even if it does not exists.
+	// required for autocompletion.
+	_ = o.Manifest.Read()
+}
+
+func (o logsOptions) logs(filter []string, follow bool) error {
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	defer close(c)
+
+	ctx := context.Background()
+
+	for i, object := range o.Manifest.Objects {
+		component, err := components.GetObject(object.Metadata.Name, o.CRD, o.Version, o.Manifest)
+		if err != nil {
+			return fmt.Errorf("creating component interface: %w", err)
+		}
+		if component == nil {
+			continue
+		}
+		if len(filter) != 0 {
+			listed := false
+			for _, name := range filter {
+				if component.GetName() == name {
+					listed = true
+					break
+				}
+			}
+			if !listed {
+				continue
+			}
+		}
+		container, ok := component.(triggermesh.Runnable)
+		if !ok {
+			continue
+		}
+		since := time.Now()
+		if !follow {
+			since = since.Add(-defaultLogPeriod * time.Hour)
+		}
+		reader, err := container.Logs(ctx, since, follow)
+		if err != nil {
+			return fmt.Errorf("%q logs unavailable: %w", component.GetName(), err)
+		}
+		defer reader.Close()
+		colorCode := func() string {
+			if len(filter) == 1 {
+				return defaultColorCode
+			}
+			if i >= len(colors) {
+				i -= len(colors)
+			}
+			return colors[i]
+		}()
+		if follow {
+			log.Printf("%sListening %s%s", colorCode, component.GetName(), defaultColorCode)
+			go readLogs(reader, c, colorCode)
+		} else {
+			fmt.Printf("---------------\n%s\n---------------\n", component.GetName())
+			readLogs(reader, c, defaultColorCode)
+		}
+	}
+	if follow {
+		<-c
+	}
+	return nil
+}
+
+func readLogs(logs io.ReadCloser, done chan os.Signal, colorCode string) {
+	scanner := bufio.NewScanner(logs)
+	for scanner.Scan() {
+		select {
+		case <-done:
+			logs.Close()
+			return
+		default:
+			log := scanner.Bytes()
+			if len(log) > 8 {
+				log = log[8:]
+			}
+			fmt.Printf("%s%s%s\n", colorCode, string(log), defaultColorCode)
+		}
+	}
+}

--- a/cmd/sendevent/sendevent.go
+++ b/cmd/sendevent/sendevent.go
@@ -54,6 +54,9 @@ func NewCmd() *cobra.Command {
 		Use:     "send-event [--eventType <type>][--target <name>] <data>",
 		Short:   "Send CloudEvent to the target",
 		Example: "tmctl send-event '{\"hello\":\"world\"}'",
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return []string{"--target", "--eventType"}, cobra.ShellCompDirectiveNoFileComp
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if target == "" {
 				target = o.Context

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -133,7 +133,7 @@ func (o *startOptions) start(broker string) error {
 		}
 		log.Printf("Starting %s\n", object.Metadata.Name)
 		if _, err := c.(triggermesh.Runnable).Start(ctx, secrets, o.Restart); err != nil {
-			return fmt.Errorf("starting container: %w", err)
+			return fmt.Errorf("starting component %q: %w", c.GetName(), err)
 		}
 		if _, ok := c.(triggermesh.Consumer); ok {
 			triggers, err := tmbroker.GetTargetTriggers(c.GetName(), o.Context, o.ConfigBase)

--- a/docs/tmctl.md
+++ b/docs/tmctl.md
@@ -24,6 +24,7 @@ Find more information at: https://docs.triggermesh.io
 * [tmctl delete](tmctl_delete.md)	 - Delete components by names
 * [tmctl describe](tmctl_describe.md)	 - List broker components and their statuses
 * [tmctl dump](tmctl_dump.md)	 - Generate Kubernetes manifest
+* [tmctl logs](tmctl_logs.md)	 - Display components logs
 * [tmctl send-event](tmctl_send-event.md)	 - Send CloudEvent to the target
 * [tmctl start](tmctl_start.md)	 - Starts TriggerMesh components
 * [tmctl stop](tmctl_stop.md)	 - Stops TriggerMesh components, removes docker containers

--- a/docs/tmctl_logs.md
+++ b/docs/tmctl_logs.md
@@ -1,0 +1,32 @@
+## tmctl logs
+
+Display components logs
+
+```
+tmctl logs [name] [flags]
+```
+
+### Examples
+
+```
+tmctl logs
+```
+
+### Options
+
+```
+  -f, --follow   Follow logs output
+  -h, --help     help for logs
+```
+
+### Options inherited from parent commands
+
+```
+      --broker string    Optional broker name.
+      --version string   TriggerMesh components version.
+```
+
+### SEE ALSO
+
+* [tmctl](tmctl.md)	 - A command line interface to build event-driven applications
+

--- a/pkg/triggermesh/adapter/adapter.go
+++ b/pkg/triggermesh/adapter/adapter.go
@@ -58,7 +58,7 @@ func RuntimeParams(object unstructured.Unstructured, image string, additionalEnv
 	co := []docker.ContainerOption{
 		docker.WithImage(image),
 		docker.WithPort(adapterPort),
-		docker.WithErrorLoggingLevel(),
+		// docker.WithErrorLoggingLevel(),
 	}
 	ho := []docker.HostOption{
 		docker.WithHostPortBinding(adapterPort),

--- a/pkg/triggermesh/components/broker/broker.go
+++ b/pkg/triggermesh/components/broker/broker.go
@@ -19,9 +19,11 @@ package broker
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -179,6 +181,21 @@ func (b *Broker) Info(ctx context.Context) (*docker.Container, error) {
 		return nil, fmt.Errorf("container object: %w", err)
 	}
 	return container.LookupHostConfig(ctx, client)
+}
+
+func (b *Broker) Logs(ctx context.Context, since time.Time, follow bool) (io.ReadCloser, error) {
+	client, err := docker.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("docker client: %w", err)
+	}
+	container, err := b.asContainer(nil)
+	if err != nil {
+		return nil, fmt.Errorf("container object: %w", err)
+	}
+	if _, err := container.LookupHostConfig(ctx, client); err != nil {
+		return nil, fmt.Errorf("container config: %w", err)
+	}
+	return container.Logs(ctx, client, since, follow)
 }
 
 func New(name, manifestPath string) (triggermesh.Component, error) {

--- a/pkg/triggermesh/components/service/service.go
+++ b/pkg/triggermesh/components/service/service.go
@@ -19,7 +19,9 @@ package service
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -202,6 +204,21 @@ func (s *Service) Info(ctx context.Context) (*docker.Container, error) {
 		return nil, fmt.Errorf("container object: %w", err)
 	}
 	return container.LookupHostConfig(ctx, client)
+}
+
+func (s *Service) Logs(ctx context.Context, since time.Time, follow bool) (io.ReadCloser, error) {
+	client, err := docker.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("docker client: %w", err)
+	}
+	container, err := s.asContainer(nil)
+	if err != nil {
+		return nil, fmt.Errorf("container object: %w", err)
+	}
+	if _, err := container.LookupHostConfig(ctx, client); err != nil {
+		return nil, fmt.Errorf("container config: %w", err)
+	}
+	return container.Logs(ctx, client, since, follow)
 }
 
 func New(name, image, broker string, role Role, params map[string]string) triggermesh.Component {

--- a/pkg/triggermesh/components/source/source.go
+++ b/pkg/triggermesh/components/source/source.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -224,6 +226,21 @@ func (s *Source) Info(ctx context.Context) (*docker.Container, error) {
 		return nil, fmt.Errorf("container object: %w", err)
 	}
 	return container.LookupHostConfig(ctx, client)
+}
+
+func (s *Source) Logs(ctx context.Context, since time.Time, follow bool) (io.ReadCloser, error) {
+	client, err := docker.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("docker client: %w", err)
+	}
+	container, err := s.asContainer(nil)
+	if err != nil {
+		return nil, fmt.Errorf("container object: %w", err)
+	}
+	if _, err := container.LookupHostConfig(ctx, client); err != nil {
+		return nil, fmt.Errorf("container config: %w", err)
+	}
+	return container.Logs(ctx, client, since, follow)
 }
 
 func (s *Source) Initialize(ctx context.Context, secrets map[string]string) (map[string]interface{}, error) {

--- a/pkg/triggermesh/components/transformation/transformation.go
+++ b/pkg/triggermesh/components/transformation/transformation.go
@@ -19,6 +19,8 @@ package transformation
 import (
 	"context"
 	"fmt"
+	"io"
+	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -183,6 +185,21 @@ func (t *Transformation) Info(ctx context.Context) (*docker.Container, error) {
 		return nil, fmt.Errorf("container object: %w", err)
 	}
 	return container.LookupHostConfig(ctx, client)
+}
+
+func (t *Transformation) Logs(ctx context.Context, since time.Time, follow bool) (io.ReadCloser, error) {
+	client, err := docker.NewClient()
+	if err != nil {
+		return nil, fmt.Errorf("docker client: %w", err)
+	}
+	container, err := t.asContainer(nil)
+	if err != nil {
+		return nil, fmt.Errorf("container object: %w", err)
+	}
+	if _, err := container.LookupHostConfig(ctx, client); err != nil {
+		return nil, fmt.Errorf("container config: %w", err)
+	}
+	return container.Logs(ctx, client, since, follow)
 }
 
 func New(name, crdFile, kind, broker, version string, spec map[string]interface{}) triggermesh.Component {

--- a/pkg/triggermesh/interfaces.go
+++ b/pkg/triggermesh/interfaces.go
@@ -18,6 +18,8 @@ package triggermesh
 
 import (
 	"context"
+	"io"
+	"time"
 
 	"github.com/triggermesh/tmctl/pkg/docker"
 	"github.com/triggermesh/tmctl/pkg/kubernetes"
@@ -38,6 +40,7 @@ type Runnable interface {
 	Start(ctx context.Context, additionalEnv map[string]string, restart bool) (*docker.Container, error)
 	Stop(context.Context) error
 	Info(context.Context) (*docker.Container, error)
+	Logs(ctx context.Context, since time.Time, follow bool) (io.ReadCloser, error)
 }
 
 // Producer is implemeted by all components that produce events.

--- a/pkg/wiretap/wiretap.go
+++ b/pkg/wiretap/wiretap.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"time"
 
 	"knative.dev/pkg/apis"
 	v1 "knative.dev/pkg/apis/duck/v1"
@@ -81,7 +82,7 @@ func (w *Wiretap) CreateAdapter(ctx context.Context) (io.ReadCloser, error) {
 		return nil, fmt.Errorf("container connect: %w", err)
 	}
 	w.Destination = fmt.Sprintf("http://host.docker.internal:%s", c.HostPort())
-	return c.Logs(ctx, w.client)
+	return c.Logs(ctx, w.client, time.Now().Add(2*time.Second), true)
 }
 
 func (w *Wiretap) CreateTrigger(eventTypes []string) error {
@@ -114,7 +115,7 @@ func (w *Wiretap) BrokerLogs(ctx context.Context) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	return broc.Logs(ctx, w.client)
+	return broc.Logs(ctx, w.client, time.Now().Add(2*time.Second), true)
 }
 
 func (w *Wiretap) Cleanup(ctx context.Context) error {


### PR DESCRIPTION
1. `alert`, `fatal` and `panic` added to the trigger-words for container startup validation procedure, read logs operation simplified. Resolves #198 

2. `tmctl logs [name] [-f]` command added to provide easier access to adapter container logs. Closes #201