### PR TITLE
Events filtering improvements

### DIFF
--- a/cmd/create/target.go
+++ b/cmd/create/target.go
@@ -149,7 +149,7 @@ func (o *createOptions) target(name, kind string, args map[string]string, eventS
 	}
 
 	for _, et := range eventTypesFilter {
-		if _, err := o.createTrigger("", t, tmbroker.FilterExactAttribute("type", et)); err != nil {
+		if _, err := o.createTrigger("", t, tmbroker.FilterAttribute("type", et)); err != nil {
 			return fmt.Errorf("creating trigger: %w", err)
 		}
 	}
@@ -213,7 +213,7 @@ func (o *createOptions) targetFromImage(name, image string, params map[string]st
 		}
 	}
 	for _, et := range eventTypesFilter {
-		if _, err := o.createTrigger("", s, tmbroker.FilterExactAttribute("type", et)); err != nil {
+		if _, err := o.createTrigger("", s, tmbroker.FilterAttribute("type", et)); err != nil {
 			return fmt.Errorf("creating trigger: %w", err)
 		}
 	}

--- a/cmd/create/transformation.go
+++ b/cmd/create/transformation.go
@@ -176,14 +176,14 @@ func (o *createOptions) transformation(name, target, file string, eventSourcesFi
 		if targetTriggers, err = tmbroker.GetTargetTriggers(targetComponent.GetName(), o.Context, o.ConfigBase); err != nil {
 			return fmt.Errorf("target triggers: %w", err)
 		}
-		if _, err := o.createTrigger("", targetComponent, tmbroker.FilterExactAttribute("type", transformationEventType)); err != nil {
+		if _, err := o.createTrigger("", targetComponent, tmbroker.FilterAttribute("type", transformationEventType)); err != nil {
 			return fmt.Errorf("create trigger: %w", err)
 		}
 	}
 
 	// updating existing triggers from sources to target
 	for _, et := range eventTypesFilter {
-		filter := tmbroker.FilterExactAttribute("type", et)
+		filter := tmbroker.FilterAttribute("type", et)
 		if _, err := o.createTrigger("", t, filter); err != nil {
 			return err
 		}

--- a/docs/tmctl_create_trigger.md
+++ b/docs/tmctl_create_trigger.md
@@ -16,6 +16,7 @@ tmctl create trigger --target sockeye --source foo-httppollersource
 
 ```
       --eventTypes strings   Event types filter
+      --filter string        Raw filter JSON
   -h, --help                 help for trigger
       --name string          Trigger name
       --source strings       Event sources filter

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/triggermesh/tmctl
 go 1.19
 
 require (
+	cloud.google.com/go/billing v1.7.0
 	cloud.google.com/go/logging v1.6.1
 	cloud.google.com/go/pubsub v1.28.0
 	cloud.google.com/go/storage v1.28.1
@@ -32,7 +33,6 @@ replace k8s.io/client-go => k8s.io/client-go v0.25.3
 
 require (
 	cloud.google.com/go v0.105.0 // indirect
-	cloud.google.com/go/billing v1.7.0 // indirect
 	cloud.google.com/go/compute v1.13.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.2 // indirect
 	cloud.google.com/go/iam v0.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1016,10 +1016,6 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/tommy-muehle/go-mnd/v2 v2.4.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/triggermesh/brokers v1.0.0 h1:XQiFFtYNMJeNhLUSSXgPkaFj4q9EnigCVR6g0XboJS4=
 github.com/triggermesh/brokers v1.0.0/go.mod h1:8tqxffAcoVUGqb2sQLPrfu3PaZ6vK3q6+oqPJH2XUq4=
-github.com/triggermesh/triggermesh v1.22.1-0.20230109061818-a1d6e63f8e0f h1:6bKnmCdI37jNFk6diDwdVwsGf0mJN/O3TqEhHpGDlxU=
-github.com/triggermesh/triggermesh v1.22.1-0.20230109061818-a1d6e63f8e0f/go.mod h1:CPokXPNGdoqG9tWbIZwBR5n3KFy03HOpx8pRrsOVnTQ=
-github.com/triggermesh/triggermesh v1.22.1-0.20230109062658-2671588cde80 h1:05utMhslnhN41p8rSDnl83uil3x4cd6e7qsb0/oQPEY=
-github.com/triggermesh/triggermesh v1.22.1-0.20230109062658-2671588cde80/go.mod h1:CPokXPNGdoqG9tWbIZwBR5n3KFy03HOpx8pRrsOVnTQ=
 github.com/triggermesh/triggermesh v1.22.1-0.20230109081212-641ec5587aef h1:GNuSTJauULsqWsAft40o5uZXujkFyByiX+VLqmo3c+k=
 github.com/triggermesh/triggermesh v1.22.1-0.20230109081212-641ec5587aef/go.mod h1:CPokXPNGdoqG9tWbIZwBR5n3KFy03HOpx8pRrsOVnTQ=
 github.com/triggermesh/triggermesh-core v1.0.0 h1:87ZfIj6ms/ahdl4Eq4q6qKJG2aRPvSyclA5SURwHE0A=

--- a/pkg/triggermesh/adapter/reconciler/external/gcp/billingsource.go
+++ b/pkg/triggermesh/adapter/reconciler/external/gcp/billingsource.go
@@ -22,6 +22,7 @@ import (
 
 	billing "cloud.google.com/go/billing/budgets/apiv1"
 	"cloud.google.com/go/pubsub"
+
 	sourcesv1alpha1 "github.com/triggermesh/triggermesh/pkg/apis/sources/v1alpha1"
 )
 

--- a/pkg/triggermesh/components/broker/trigger.go
+++ b/pkg/triggermesh/components/broker/trigger.go
@@ -179,7 +179,21 @@ func (t *Trigger) LookupTarget() {
 	}
 }
 
-func FilterExactAttribute(attribute, value string) *eventingbroker.Filter {
+func FilterAttribute(attribute, value string) *eventingbroker.Filter {
+	switch {
+	case strings.HasPrefix(value, "*"): // *-foo
+		return &eventingbroker.Filter{
+			Suffix: map[string]string{
+				attribute: strings.TrimSpace(strings.TrimLeft(value, "*")),
+			},
+		}
+	case strings.HasSuffix(value, "*"): // foo-*
+		return &eventingbroker.Filter{
+			Prefix: map[string]string{
+				attribute: strings.TrimSpace(strings.TrimRight(value, "*")),
+			},
+		}
+	}
 	return &eventingbroker.Filter{
 		Exact: map[string]string{attribute: strings.TrimSpace(value)},
 	}


### PR DESCRIPTION
1. Values passed with `--eventTypes` flag now can contain `*` symbol as a **prefix** or **suffix** to set trigger's filtering condition to "prefix" or "suffix" accordingly, related to #215,
2. `tmctl create trigger` supports `--filter` argument which, if passed, will be encoded directly into filter structure and passed to trigger specification, e.g.: 
    ```
    tmctl create trigger --target sockeye --filter '{"Not":{"Exact":{"source":"foo"}}}'
    ```
3. `tmctl describe` updated to work with new possible triggers output