### PR TITLE
Skip TCP connection on localhost

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+test/e2e/_run/
 releases/

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -69,7 +69,7 @@ Find more information at: https://docs.triggermesh.io`,
 
 	rootCmd.AddCommand(brokers.NewCmd(c))
 	rootCmd.AddCommand(create.NewCmd(c, manifest))
-	rootCmd.AddCommand(config.NewCmd(c))
+	rootCmd.AddCommand(config.NewCmd())
 	rootCmd.AddCommand(delete.NewCmd(c, manifest))
 	rootCmd.AddCommand(describe.NewCmd(c, manifest))
 	rootCmd.AddCommand(dump.NewCmd(c, manifest))

--- a/cmd/config/cmd.go
+++ b/cmd/config/cmd.go
@@ -24,7 +24,7 @@ import (
 	cliconfig "github.com/triggermesh/tmctl/pkg/config"
 )
 
-func NewCmd(c *cliconfig.Config) *cobra.Command {
+func NewCmd() *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:   "config [set|get]",
 		Short: "Read and write config values",
@@ -32,33 +32,38 @@ func NewCmd(c *cliconfig.Config) *cobra.Command {
 			cmd.HelpFunc()(cmd, args)
 		},
 	}
-	configCmd.AddCommand(getCmd(c))
-	configCmd.AddCommand(newSetCmd(c))
+	configCmd.AddCommand(getCmd())
+	configCmd.AddCommand(setCmd())
 	return configCmd
 }
 
-func getCmd(c *cliconfig.Config) *cobra.Command {
+func getCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "get [key]",
 		Short: "Read config value",
 		Args:  cobra.RangeArgs(0, 1),
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			key := ""
 			if len(args) == 1 {
 				key = args[0]
 			}
-			fmt.Println(c.Get(key))
+			value, err := cliconfig.Get(key)
+			if err != nil {
+				return err
+			}
+			fmt.Println(value)
+			return nil
 		},
 	}
 }
 
-func newSetCmd(c *cliconfig.Config) *cobra.Command {
+func setCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "set <key> <value>",
 		Short: "Write config value",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return c.Set(args[0], args[1])
+			return cliconfig.Set(args[0], args[1])
 		},
 	}
 }

--- a/pkg/config/overrides.go
+++ b/pkg/config/overrides.go
@@ -22,6 +22,7 @@ type configOverride func(*Config) bool
 
 var overrides = []configOverride{
 	brokerImageReplacement(),
+	dockerTimeoutAppend(),
 }
 
 func (c *Config) applyOverrides() error {
@@ -55,6 +56,16 @@ func brokerImageReplacement() configOverride {
 			c.Triggermesh.Broker.Version = latestOrDefaultTag("brokers", defaultBrokerVersion)
 		}
 		c.Triggermesh.Broker.Image = ""
+		return true
+	}
+}
+
+func dockerTimeoutAppend() configOverride {
+	return func(c *Config) bool {
+		if c.Docker.StartTimeout != "" {
+			return false
+		}
+		c.Docker.StartTimeout = defaultDockerTimeout
 		return true
 	}
 }

--- a/pkg/wiretap/wiretap.go
+++ b/pkg/wiretap/wiretap.go
@@ -79,9 +79,6 @@ func (w *Wiretap) CreateAdapter(ctx context.Context) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, fmt.Errorf("starting container: %w", err)
 	}
-	if err := c.Connect(ctx); err != nil {
-		return nil, fmt.Errorf("container connect: %w", err)
-	}
 	w.Destination = fmt.Sprintf("http://host.docker.internal:%s", c.HostPort())
 	return c.Logs(ctx, w.client, time.Now().Add(2*time.Second), true)
 }


### PR DESCRIPTION
- `container.Connect` method that checked the container's TCP port on the local Docker host is replaced with the container's status inspection using the Docker client. With this update, CLI should not require the Docker engine to run on the local host,
- Container initialization timeout configurable through the CLI configuration file,
- Container startup logs validation improvement - check unstructured log data for Go's panic dump.

Related to triggermesh/triggermesh#1287