### PR TITLE
Trigger name with multiple eventTypes fix

### DIFF
--- a/cmd/create/trigger.go
+++ b/cmd/create/trigger.go
@@ -19,6 +19,7 @@ package create
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -95,10 +96,40 @@ func (o *CliOptions) trigger(name string, rawFilter string, eventSourcesFilter, 
 			return err
 		}
 	}
-	for _, filter := range filters {
-		if _, err = o.createTrigger(name, component, filter); err != nil {
+
+	oldTriggers := o.listTriggers(name + "-")
+	for i, filter := range filters {
+		newTrigger := name
+		if name != "" {
+			newTrigger = fmt.Sprintf("%s-%d", name, i+1)
+		}
+		if _, err = o.createTrigger(newTrigger, component, filter); err != nil {
+			return err
+		}
+		delete(oldTriggers, newTrigger)
+	}
+
+	for _, oldTrigger := range oldTriggers {
+		if err := oldTrigger.RemoveFromLocalConfig(); err != nil {
+			return err
+		}
+		if err := o.Manifest.Remove(oldTrigger.Name, oldTrigger.GetKind()); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func (o *CliOptions) listTriggers(prefix string) map[string]*tmbroker.Trigger {
+	result := make(map[string]*tmbroker.Trigger, 0)
+	for _, v := range o.Manifest.Objects {
+		if v.Kind == tmbroker.TriggerKind && strings.HasPrefix(v.Metadata.Name, prefix) {
+			trigger, err := tmbroker.NewTrigger(v.Metadata.Name, o.Config.Context, o.Config.ConfigHome, nil, nil)
+			if err != nil {
+				continue
+			}
+			result[v.Metadata.Name] = trigger.(*tmbroker.Trigger)
+		}
+	}
+	return result
 }


### PR DESCRIPTION
This PR provides a fix for an issue described in #221.

Updated behavior for `tmctl create trigger` command with multiple eventTypes filter and single trigger name - `--name foo --eventTypes a,b,c` will result in triggers `foo-1`, `foo-2`, and `foo-3` with `a`, `b`, and `c` type filters to be created. Details of the proposed fix are [here](https://github.com/triggermesh/tmctl/issues/221#issuecomment-1410378957).