### PR TITLE
Preload manifest for completion

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -18,6 +18,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
@@ -37,6 +38,8 @@ import (
 
 	cliconfig "github.com/triggermesh/tmctl/pkg/config"
 	"github.com/triggermesh/tmctl/pkg/log"
+	"github.com/triggermesh/tmctl/pkg/manifest"
+	"github.com/triggermesh/tmctl/pkg/triggermesh"
 	"github.com/triggermesh/tmctl/pkg/triggermesh/crd"
 )
 
@@ -50,25 +53,31 @@ Find more information at: https://docs.triggermesh.io`,
 		// CompletionOptions: cobra.CompletionOptions{DisableDescriptions: true},
 	}
 
-	conf, err := cliconfig.New()
+	c, err := cliconfig.New()
 	cobra.CheckErr(err)
-	crds, err := crd.Fetch(conf.ConfigHome, conf.Triggermesh.ComponentsVersion)
+	crds, err := crd.Fetch(c.ConfigHome, c.Triggermesh.ComponentsVersion)
 	cobra.CheckErr(err)
 
-	rootCmd.AddCommand(brokers.NewCmd(conf))
-	rootCmd.AddCommand(create.NewCmd(conf, crds))
+	manifest := manifest.New(filepath.Join(
+		c.ConfigHome,
+		c.Context,
+		triggermesh.ManifestFile))
+	_ = manifest.Read()
+
+	rootCmd.AddCommand(brokers.NewCmd(c))
+	rootCmd.AddCommand(create.NewCmd(c, manifest, crds))
 	rootCmd.AddCommand(config.NewCmd())
-	rootCmd.AddCommand(delete.NewCmd(conf, crds))
-	rootCmd.AddCommand(describe.NewCmd(conf, crds))
-	rootCmd.AddCommand(dump.NewCmd(conf, crds))
-	rootCmd.AddCommand(logs.NewCmd(conf, crds))
-	rootCmd.AddCommand(sendevent.NewCmd(conf, crds))
-	rootCmd.AddCommand(start.NewCmd(conf, crds))
-	rootCmd.AddCommand(stop.NewCmd(conf))
-	rootCmd.AddCommand(watch.NewCmd(conf))
-	rootCmd.AddCommand(version.NewCmd(ver, commit, conf))
+	rootCmd.AddCommand(delete.NewCmd(c, manifest, crds))
+	rootCmd.AddCommand(describe.NewCmd(c, manifest, crds))
+	rootCmd.AddCommand(dump.NewCmd(c, manifest, crds))
+	rootCmd.AddCommand(logs.NewCmd(c, manifest, crds))
+	rootCmd.AddCommand(sendevent.NewCmd(c, manifest, crds))
+	rootCmd.AddCommand(start.NewCmd(c, manifest, crds))
+	rootCmd.AddCommand(stop.NewCmd(c, manifest))
+	rootCmd.AddCommand(watch.NewCmd(c))
+	rootCmd.AddCommand(version.NewCmd(ver, commit, c))
 
-	rootCmd.PersistentFlags().StringVar(&conf.Triggermesh.ComponentsVersion, "version", conf.Triggermesh.ComponentsVersion, "TriggerMesh components version.")
+	rootCmd.PersistentFlags().StringVar(&c.Triggermesh.ComponentsVersion, "version", c.Triggermesh.ComponentsVersion, "TriggerMesh components version.")
 	cobra.CheckErr(rootCmd.RegisterFlagCompletionFunc("version", cobra.NoFileCompletions))
 
 	if os.Getenv("TMCTL_GENERATE_DOCS") == "true" {

--- a/cmd/create/cmd.go
+++ b/cmd/create/cmd.go
@@ -18,7 +18,6 @@ package create
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -37,14 +36,11 @@ type CliOptions struct {
 	CRD      map[string]crd.CRD
 }
 
-func NewCmd(config *config.Config, crds map[string]crd.CRD) *cobra.Command {
+func NewCmd(config *config.Config, manifest *manifest.Manifest, crds map[string]crd.CRD) *cobra.Command {
 	o := &CliOptions{
-		CRD:    crds,
-		Config: config,
-		Manifest: manifest.New(filepath.Join(
-			config.ConfigHome,
-			config.Context,
-			triggermesh.ManifestFile)),
+		CRD:      crds,
+		Config:   config,
+		Manifest: manifest,
 	}
 	createCmd := &cobra.Command{
 		Use:   "create <kind>",

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -45,14 +45,11 @@ type CliOptions struct {
 	CRD      map[string]crd.CRD
 }
 
-func NewCmd(config *config.Config, crd map[string]crd.CRD) *cobra.Command {
+func NewCmd(config *config.Config, manifest *manifest.Manifest, crd map[string]crd.CRD) *cobra.Command {
 	o := &CliOptions{
-		CRD:    crd,
-		Config: config,
-		Manifest: manifest.New(filepath.Join(
-			config.ConfigHome,
-			config.Context,
-			triggermesh.ManifestFile)),
+		CRD:      crd,
+		Config:   config,
+		Manifest: manifest,
 	}
 	var broker string
 	deleteCmd := &cobra.Command{

--- a/cmd/describe/describe.go
+++ b/cmd/describe/describe.go
@@ -52,14 +52,11 @@ type CliOptions struct {
 	CRD      map[string]crd.CRD
 }
 
-func NewCmd(config *config.Config, crd map[string]crd.CRD) *cobra.Command {
+func NewCmd(config *config.Config, m *manifest.Manifest, crd map[string]crd.CRD) *cobra.Command {
 	o := &CliOptions{
-		CRD:    crd,
-		Config: config,
-		Manifest: manifest.New(filepath.Join(
-			config.ConfigHome,
-			config.Context,
-			triggermesh.ManifestFile)),
+		CRD:      crd,
+		Config:   config,
+		Manifest: m,
 	}
 	return &cobra.Command{
 		Use:     "describe [broker]",

--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -59,14 +59,11 @@ type CliOptions struct {
 	Platform string
 }
 
-func NewCmd(config *config.Config, crd map[string]crd.CRD) *cobra.Command {
+func NewCmd(config *config.Config, m *manifest.Manifest, crd map[string]crd.CRD) *cobra.Command {
 	o := &CliOptions{
-		CRD:    crd,
-		Config: config,
-		Manifest: manifest.New(filepath.Join(
-			config.ConfigHome,
-			config.Context,
-			triggermesh.ManifestFile)),
+		CRD:      crd,
+		Config:   config,
+		Manifest: m,
 	}
 	do := &doOptions{}
 	dumpCmd := &cobra.Command{

--- a/cmd/logs/logs.go
+++ b/cmd/logs/logs.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -63,14 +62,11 @@ type CliOptions struct {
 	CRD      map[string]crd.CRD
 }
 
-func NewCmd(config *config.Config, crd map[string]crd.CRD) *cobra.Command {
+func NewCmd(config *config.Config, manifest *manifest.Manifest, crd map[string]crd.CRD) *cobra.Command {
 	o := &CliOptions{
-		CRD:    crd,
-		Config: config,
-		Manifest: manifest.New(filepath.Join(
-			config.ConfigHome,
-			config.Context,
-			triggermesh.ManifestFile)),
+		CRD:      crd,
+		Config:   config,
+		Manifest: manifest,
 	}
 	var follow bool
 	logsCmd := &cobra.Command{

--- a/cmd/sendevent/sendevent.go
+++ b/cmd/sendevent/sendevent.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	cloudevents "github.com/cloudevents/sdk-go/v2"
@@ -45,14 +44,11 @@ type CliOptions struct {
 	CRD      map[string]crd.CRD
 }
 
-func NewCmd(config *config.Config, crd map[string]crd.CRD) *cobra.Command {
+func NewCmd(config *config.Config, manifest *manifest.Manifest, crd map[string]crd.CRD) *cobra.Command {
 	o := &CliOptions{
-		CRD:    crd,
-		Config: config,
-		Manifest: manifest.New(filepath.Join(
-			config.ConfigHome,
-			config.Context,
-			triggermesh.ManifestFile)),
+		CRD:      crd,
+		Config:   config,
+		Manifest: manifest,
 	}
 	var eventType, target string
 	sendCmd := &cobra.Command{

--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -41,14 +41,11 @@ type CliOptions struct {
 	Restart bool
 }
 
-func NewCmd(config *config.Config, crd map[string]crd.CRD) *cobra.Command {
+func NewCmd(config *config.Config, m *manifest.Manifest, crd map[string]crd.CRD) *cobra.Command {
 	o := &CliOptions{
-		CRD:    crd,
-		Config: config,
-		Manifest: manifest.New(filepath.Join(
-			config.ConfigHome,
-			config.Context,
-			triggermesh.ManifestFile)),
+		CRD:      crd,
+		Config:   config,
+		Manifest: m,
 	}
 	createCmd := &cobra.Command{
 		Use:     "start [broker]",

--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -36,13 +36,10 @@ type CliOptions struct {
 	Manifest *manifest.Manifest
 }
 
-func NewCmd(config *config.Config) *cobra.Command {
+func NewCmd(config *config.Config, m *manifest.Manifest) *cobra.Command {
 	o := &CliOptions{
-		Config: config,
-		Manifest: manifest.New(filepath.Join(
-			config.ConfigHome,
-			config.Context,
-			triggermesh.ManifestFile)),
+		Config:   config,
+		Manifest: m,
 	}
 	return &cobra.Command{
 		Use:     "stop [broker]",


### PR DESCRIPTION
Fix for autocompletion - the previous update removed preload of the default manifest required for completion functions to list existing objects