### PR TITLE
Sync TriggerMesh components

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.1
 	github.com/triggermesh/brokers v1.1.1
-	github.com/triggermesh/triggermesh v1.23.3
+	github.com/triggermesh/triggermesh v1.23.1-0.20230221073043-5c2326b5159a
 	github.com/triggermesh/triggermesh-core v1.1.1
 	google.golang.org/api v0.108.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -43,7 +43,7 @@ require (
 	contrib.go.opencensus.io/exporter/zipkin v0.1.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.0 // indirect
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
-	github.com/Azure/go-autorest/autorest/adal v0.9.21 // indirect
+	github.com/Azure/go-autorest/autorest/adal v0.9.22 // indirect
 	github.com/Azure/go-autorest/autorest/azure/cli v0.4.5 // indirect
 	github.com/Azure/go-autorest/autorest/date v0.3.0 // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
@@ -124,7 +124,6 @@ require (
 	github.com/tidwall/pretty v1.2.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/goleak v1.1.12 // indirect
 	go.uber.org/multierr v1.8.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
 	golang.org/x/crypto v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,8 +95,8 @@ github.com/Azure/go-autorest/autorest v0.11.28 h1:ndAExarwr5Y+GaHE6VCaY1kyS/HwwG
 github.com/Azure/go-autorest/autorest v0.11.28/go.mod h1:MrkzG3Y3AH668QyF9KRk5neJnGgmhQ6krbhR8Q5eMvA=
 github.com/Azure/go-autorest/autorest/adal v0.9.18/go.mod h1:XVVeme+LZwABT8K5Lc3hA4nAe8LDBVle26gTrguhhPQ=
 github.com/Azure/go-autorest/autorest/adal v0.9.20/go.mod h1:XVVeme+LZwABT8K5Lc3hA4nAe8LDBVle26gTrguhhPQ=
-github.com/Azure/go-autorest/autorest/adal v0.9.21 h1:jjQnVFXPfekaqb8vIsv2G1lxshoW+oGv4MDlhRtnYZk=
-github.com/Azure/go-autorest/autorest/adal v0.9.21/go.mod h1:zua7mBUaCc5YnSLKYgGJR/w5ePdMDA6H56upLsHzA9U=
+github.com/Azure/go-autorest/autorest/adal v0.9.22 h1:/GblQdIudfEM3AWWZ0mrYJQSd7JS4S/Mbzh6F0ov0Xc=
+github.com/Azure/go-autorest/autorest/adal v0.9.22/go.mod h1:XuAbAEUv2Tta//+voMI038TrJBqjKam0me7qR+L8Cmk=
 github.com/Azure/go-autorest/autorest/azure/auth v0.5.12 h1:wkAZRgT/pn8HhFyzfe9UnqOjJYqlembgCTi72Bm/xKk=
 github.com/Azure/go-autorest/autorest/azure/auth v0.5.12/go.mod h1:84w/uV8E37feW2NCJ08uT9VBfjfUHpgLVnG2InYD6cg=
 github.com/Azure/go-autorest/autorest/azure/cli v0.4.5 h1:0W/yGmFdTIT77fvdlGZ0LMISoLHFJ7Tx4U0yeB+uFs4=
@@ -1002,8 +1002,8 @@ github.com/tomasen/realip v0.0.0-20180522021738-f0c99a92ddce/go.mod h1:o8v6yHRoi
 github.com/tommy-muehle/go-mnd/v2 v2.4.0/go.mod h1:WsUAkMJMYww6l/ufffCD3m+P7LEvr8TnZn9lwVDlgzw=
 github.com/triggermesh/brokers v1.1.1 h1:te1+VHMBzqLClhh1sVGQw3nJuUQxCPzcpgNmVXRWVc4=
 github.com/triggermesh/brokers v1.1.1/go.mod h1:b8EDQkygFFHn83rN+T8g0JkD6ZVqJFjm5N1PWIbCFt4=
-github.com/triggermesh/triggermesh v1.23.3 h1:pxUVR9O+wX3YOJLhflY7YfjaLVdMeBHToUWt1+xQftA=
-github.com/triggermesh/triggermesh v1.23.3/go.mod h1:I4Tk6+tOzHRJ+eWa90PYQeNM9myyTG0g73lK3VBvCv4=
+github.com/triggermesh/triggermesh v1.23.1-0.20230221073043-5c2326b5159a h1:kkpdn/EQI38QbQSjOF4jWOv+ZYPaezr1DsVUG/cIVWU=
+github.com/triggermesh/triggermesh v1.23.1-0.20230221073043-5c2326b5159a/go.mod h1:QsT5rGh8b4EzsFIhutiV0jCyVFSTIG1yyt3+IACOlho=
 github.com/triggermesh/triggermesh-core v1.1.1 h1:g4EG9VT0qqakgayYBtEio4lOYQJvFM3By4ehsw7W93Q=
 github.com/triggermesh/triggermesh-core v1.1.1/go.mod h1:f4HsTXKfUFFwkaCVxBSjm+WghwdSTX6Xc2BZMQNjGrQ=
 github.com/tsenart/go-tsz v0.0.0-20180814232043-cdeb9e1e981e/go.mod h1:SWZznP1z5Ki7hDT2ioqiFKEse8K9tU2OUvaRI0NeGQo=
@@ -1086,7 +1086,6 @@ go.uber.org/automaxprocs v1.4.0/go.mod h1:/mTEdr7LvHhs0v7mjdxDreTz1OG5zdZGqgOnhW
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
 go.uber.org/goleak v1.1.11-0.20210813005559-691160354723/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/goleak v1.1.12 h1:gZAh5/EyT/HQwlpkCy6wTpqfH9H8Lz8zbm3dZh+OyzA=
-go.uber.org/goleak v1.1.12/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.4.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=

--- a/pkg/triggermesh/adapter/ce/sources.go
+++ b/pkg/triggermesh/adapter/ce/sources.go
@@ -306,6 +306,15 @@ func sources(object unstructured.Unstructured) (EventAttributes, error) {
 			ProducedEventTypes:  o.GetEventTypes(),
 			ProducedEventSource: o.AsEventSource(),
 		}, nil
+	case "SolaceSource":
+		var o *sourcesv1alpha1.SolaceSource
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
+			return EventAttributes{}, err
+		}
+		return EventAttributes{
+			ProducedEventTypes:  o.GetEventTypes(),
+			ProducedEventSource: o.AsEventSource(),
+		}, nil
 	case "TwilioSource":
 		var o *sourcesv1alpha1.TwilioSource
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {

--- a/pkg/triggermesh/adapter/ce/targets.go
+++ b/pkg/triggermesh/adapter/ce/targets.go
@@ -27,17 +27,6 @@ import (
 
 func targets(object unstructured.Unstructured) (EventAttributes, error) {
 	switch object.GetKind() {
-	// Flow API group
-	case "AlibabaOSSTarget":
-		var o *targetsv1alpha1.AlibabaOSSTarget
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
-			return EventAttributes{}, err
-		}
-		return EventAttributes{
-			ProducedEventTypes:  o.GetEventTypes(),
-			ProducedEventSource: o.AsEventSource(),
-			AcceptedEventTypes:  o.AcceptedEventTypes(),
-		}, nil
 	case "AWSComprehendTarget":
 		var o *targetsv1alpha1.AWSComprehendTarget
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
@@ -158,16 +147,6 @@ func targets(object unstructured.Unstructured) (EventAttributes, error) {
 			ProducedEventSource: o.AsEventSource(),
 			AcceptedEventTypes:  o.AcceptedEventTypes(),
 		}, nil
-	case "HasuraTarget":
-		var o *targetsv1alpha1.HasuraTarget
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
-			return EventAttributes{}, err
-		}
-		return EventAttributes{
-			ProducedEventTypes:  o.GetEventTypes(),
-			ProducedEventSource: o.AsEventSource(),
-			AcceptedEventTypes:  o.AcceptedEventTypes(),
-		}, nil
 	case "HTTPTarget":
 		return EventAttributes{}, nil
 	case "IBMMQTarget":
@@ -209,6 +188,16 @@ func targets(object unstructured.Unstructured) (EventAttributes, error) {
 			ProducedEventTypes:  o.GetEventTypes(),
 			ProducedEventSource: o.AsEventSource(),
 		}, nil
+	case "MongoDBTarget":
+		var o *targetsv1alpha1.MongoDBTarget
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
+			return EventAttributes{}, err
+		}
+		return EventAttributes{
+			ProducedEventTypes:  o.GetEventTypes(),
+			ProducedEventSource: o.AsEventSource(),
+			AcceptedEventTypes:  o.AcceptedEventTypes(),
+		}, nil
 	case "OracleTarget":
 		return EventAttributes{}, nil
 	case "SalesforceTarget":
@@ -241,18 +230,10 @@ func targets(object unstructured.Unstructured) (EventAttributes, error) {
 			ProducedEventSource: o.AsEventSource(),
 			AcceptedEventTypes:  o.AcceptedEventTypes(),
 		}, nil
+	case "SolaceTarget":
+		return EventAttributes{}, nil
 	case "SplunkTarget":
 		return EventAttributes{}, nil
-	case "TektonTarget":
-		var o *targetsv1alpha1.TektonTarget
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
-			return EventAttributes{}, err
-		}
-		return EventAttributes{
-			ProducedEventTypes:  o.GetEventTypes(),
-			ProducedEventSource: o.AsEventSource(),
-			AcceptedEventTypes:  o.AcceptedEventTypes(),
-		}, nil
 	case "TwilioTarget":
 		var o *targetsv1alpha1.TwilioTarget
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {

--- a/pkg/triggermesh/adapter/env/flow.go
+++ b/pkg/triggermesh/adapter/env/flow.go
@@ -25,7 +25,6 @@ import (
 
 	flowv1alpha1 "github.com/triggermesh/triggermesh/pkg/apis/flow/v1alpha1"
 
-	"github.com/triggermesh/triggermesh/pkg/flow/reconciler/dataweavetransformation"
 	"github.com/triggermesh/triggermesh/pkg/flow/reconciler/jqtransformation"
 	"github.com/triggermesh/triggermesh/pkg/flow/reconciler/transformation"
 	"github.com/triggermesh/triggermesh/pkg/flow/reconciler/xmltojsontransformation"
@@ -47,12 +46,6 @@ func flow(object unstructured.Unstructured) ([]corev1.EnvVar, error) {
 			return nil, err
 		}
 		return xslttransformation.MakeAppEnv(o), nil
-	case "DataWeaveTransformation":
-		var o *flowv1alpha1.DataWeaveTransformation
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
-			return nil, err
-		}
-		return dataweavetransformation.MakeAppEnv(o), nil
 	case "XMLToJSONTransformation":
 		var o *flowv1alpha1.XMLToJSONTransformation
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {

--- a/pkg/triggermesh/adapter/env/sources.go
+++ b/pkg/triggermesh/adapter/env/sources.go
@@ -56,6 +56,7 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/ocimetricssource"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/salesforcesource"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/slacksource"
+	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/solacesource"
 	"github.com/triggermesh/triggermesh/pkg/sources/reconciler/webhooksource"
 )
 
@@ -247,6 +248,12 @@ func sources(object unstructured.Unstructured) ([]corev1.EnvVar, error) {
 			return nil, err
 		}
 		return slacksource.MakeAppEnv(o), nil
+	case "SolaceSource":
+		var o *sourcesv1alpha1.SolaceSource
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
+			return nil, err
+		}
+		return solacesource.MakeAppEnv(o), nil
 	case "TwilioSource":
 		return []corev1.EnvVar{}, nil
 	case "WebhookSource":

--- a/pkg/triggermesh/adapter/env/targets.go
+++ b/pkg/triggermesh/adapter/env/targets.go
@@ -25,7 +25,6 @@ import (
 
 	targetsv1alpha1 "github.com/triggermesh/triggermesh/pkg/apis/targets/v1alpha1"
 
-	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/alibabaosstarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/awscomprehendtarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/awsdynamodbtarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/awseventbridgetarget"
@@ -36,7 +35,6 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/awssqstarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/azureeventhubstarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/cloudeventstarget"
-	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/confluenttarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/datadogtarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/elasticsearchtarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/googlecloudfirestoretarget"
@@ -44,32 +42,25 @@ import (
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/googlecloudstoragetarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/googlecloudworkflowstarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/googlesheettarget"
-	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/hasuratarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/httptarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/ibmmqtarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/jiratarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/kafkatarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/logzmetricstarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/logztarget"
+	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/mongodbtarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/oracletarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/salesforcetarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/sendgridtarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/slacktarget"
+	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/solacetarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/splunktarget"
-	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/tektontarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/twiliotarget"
 	"github.com/triggermesh/triggermesh/pkg/targets/reconciler/zendesktarget"
 )
 
 func targets(object unstructured.Unstructured) ([]corev1.EnvVar, error) {
 	switch object.GetKind() {
-	// Flow API group
-	case "AlibabaOSSTarget":
-		var o *targetsv1alpha1.AlibabaOSSTarget
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
-			return nil, err
-		}
-		return alibabaosstarget.MakeAppEnv(o), nil
 	case "AWSComprehendTarget":
 		var o *targetsv1alpha1.AWSComprehendTarget
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
@@ -130,12 +121,6 @@ func targets(object unstructured.Unstructured) ([]corev1.EnvVar, error) {
 			return nil, err
 		}
 		return cloudeventstarget.MakeAppEnv(o), nil
-	case "ConfluentTarget":
-		var o *targetsv1alpha1.ConfluentTarget
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
-			return nil, err
-		}
-		return confluenttarget.MakeAppEnv(o), nil
 	case "DatadogTarget":
 		var o *targetsv1alpha1.DatadogTarget
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
@@ -178,12 +163,6 @@ func targets(object unstructured.Unstructured) ([]corev1.EnvVar, error) {
 			return nil, err
 		}
 		return googlesheettarget.MakeAppEnv(o), nil
-	case "HasuraTarget":
-		var o *targetsv1alpha1.HasuraTarget
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
-			return nil, err
-		}
-		return hasuratarget.MakeAppEnv(o), nil
 	case "HTTPTarget":
 		var o *targetsv1alpha1.HTTPTarget
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
@@ -220,6 +199,12 @@ func targets(object unstructured.Unstructured) ([]corev1.EnvVar, error) {
 			return nil, err
 		}
 		return logztarget.MakeAppEnv(o), nil
+	case "MongoDBTarget":
+		var o *targetsv1alpha1.MongoDBTarget
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
+			return nil, err
+		}
+		return mongodbtarget.MakeAppEnv(o), nil
 	case "OracleTarget":
 		var o *targetsv1alpha1.OracleTarget
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
@@ -244,18 +229,18 @@ func targets(object unstructured.Unstructured) ([]corev1.EnvVar, error) {
 			return nil, err
 		}
 		return slacktarget.MakeAppEnv(o), nil
+	case "SolaceTarget":
+		var o *targetsv1alpha1.SolaceTarget
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
+			return nil, err
+		}
+		return solacetarget.MakeAppEnv(o), nil
 	case "SplunkTarget":
 		var o *targetsv1alpha1.SplunkTarget
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
 			return nil, err
 		}
 		return splunktarget.MakeAppEnv(o), nil
-	case "TektonTarget":
-		var o *targetsv1alpha1.TektonTarget
-		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
-			return nil, err
-		}
-		return tektontarget.MakeAppEnv(o), nil
 	case "TwilioTarget":
 		var o *targetsv1alpha1.TwilioTarget
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {


### PR DESCRIPTION
Sync with the latest TriggerMesh.
Removed:
- AlibabaOSSTarget
- HasuraTarget
- TektonTarget
- DataWeaveTransformation
- ConfluentTarget

Added:
- SolaceSource
- SolaceTarget
- MongoDBTarget
