### PR TITLE
Fallback to CRD event annotations if reconciler's method is failing

### DIFF
--- a/pkg/triggermesh/crd/crd.go
+++ b/pkg/triggermesh/crd/crd.go
@@ -63,7 +63,8 @@ type CRD struct {
 	Metadata   struct {
 		Name        string `yaml:"name"`
 		Annotations struct {
-			EventTypes string `yaml:"registry.knative.dev/eventTypes"`
+			ProducedEventTypes string `yaml:"registry.knative.dev/eventTypes"`
+			ConsumedEventTypes string `yaml:"registry.triggermesh.io/acceptedEventTypes"`
 		} `yaml:"annotations"`
 	} `yaml:"metadata"`
 	Spec struct {
@@ -94,7 +95,8 @@ type CRD struct {
 }
 
 type EventTypes []struct {
-	Type string `json:"type"`
+	Type   string `json:"type"`
+	Schema string `json:"schema"`
 }
 
 // Fetch downloads the release version of TriggerMesh CRDs for specified version.


### PR DESCRIPTION
There are edge cases when retrieving (custom version) component's event attributes from the imported method is failing, i.e. object won't pass conversion to `unstructured.Unstructured` if the new CRD has an incompatible change. For these cases, sources and now targets will try to parse CRD's event attribute annotations to get this data if it is available.