### PR TITLE
Fix broker in-memory config on Windows

### DIFF
--- a/pkg/triggermesh/components/broker/broker.go
+++ b/pkg/triggermesh/components/broker/broker.go
@@ -308,9 +308,9 @@ func brokerEntrypoint(c config.BrokerConfig) []string {
 		if c.Redis.SkipVerify {
 			entrypoint = append(entrypoint, "--redis.tls-skip-verify")
 		}
-		if c.ConfigPollingPeriod != "" {
-			entrypoint = append(entrypoint, []string{"--config-polling-period", c.ConfigPollingPeriod}...)
-		}
+	}
+	if c.ConfigPollingPeriod != "" {
+		entrypoint = append(entrypoint, []string{"--config-polling-period", c.ConfigPollingPeriod}...)
 	}
 	return append(entrypoint, []string{"--broker-config-path", "/etc/triggermesh/broker.conf"}...)
 }


### PR DESCRIPTION
Fix for Windows in-memory broker entrypoint issue - after we reworked the CLI configuration module and added Redis support, one line slipped out of its conditional scope and caused the wrong behavior for in-memory brokers on the Windows platform. 