### PR TITLE
CE transformation improvements

### DIFF
--- a/docs/tmctl.md
+++ b/docs/tmctl.md
@@ -12,7 +12,7 @@ Find more information at: https://docs.triggermesh.io
 
 ```
   -h, --help             help for tmctl
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_brokers.md
+++ b/docs/tmctl_brokers.md
@@ -16,7 +16,7 @@ tmctl brokers [--set <broker>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_config.md
+++ b/docs/tmctl_config.md
@@ -15,7 +15,7 @@ tmctl config [set|get] [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_config_get.md
+++ b/docs/tmctl_config_get.md
@@ -15,7 +15,7 @@ tmctl config get [key] [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_config_set.md
+++ b/docs/tmctl_config_set.md
@@ -15,7 +15,7 @@ tmctl config set <key> <value> [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create.md
+++ b/docs/tmctl_create.md
@@ -11,7 +11,7 @@ Create TriggerMesh component
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create_broker.md
+++ b/docs/tmctl_create_broker.md
@@ -16,7 +16,7 @@ tmctl create broker foo
 
 ```
   -h, --help             help for broker
-      --version string   TriggerMesh broker version. (default "v1.2.0")
+      --version string   TriggerMesh broker version. (default "v1.2.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create_source.md
+++ b/docs/tmctl_create_source.md
@@ -25,7 +25,7 @@ tmctl create source httppoller \
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create_target.md
+++ b/docs/tmctl_create_target.md
@@ -24,7 +24,7 @@ tmctl create target http \
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create_transformation.md
+++ b/docs/tmctl_create_transformation.md
@@ -32,7 +32,7 @@ EOF
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create_trigger.md
+++ b/docs/tmctl_create_trigger.md
@@ -26,7 +26,7 @@ tmctl create trigger --target sockeye --source foo-httppollersource
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_delete.md
+++ b/docs/tmctl_delete.md
@@ -23,7 +23,7 @@ tmctl delete --broker foo
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_describe.md
+++ b/docs/tmctl_describe.md
@@ -21,7 +21,7 @@ tmctl describe
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_dump.md
+++ b/docs/tmctl_dump.md
@@ -26,7 +26,7 @@ tmctl dump
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_import.md
+++ b/docs/tmctl_import.md
@@ -22,7 +22,7 @@ tmctl import -f manifest.yaml
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_logs.md
+++ b/docs/tmctl_logs.md
@@ -22,7 +22,7 @@ tmctl logs
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_send-event.md
+++ b/docs/tmctl_send-event.md
@@ -23,7 +23,7 @@ tmctl send-event '{"hello":"world"}'
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_start.md
+++ b/docs/tmctl_start.md
@@ -22,7 +22,7 @@ tmctl start
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_stop.md
+++ b/docs/tmctl_stop.md
@@ -21,7 +21,7 @@ tmctl stop
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_version.md
+++ b/docs/tmctl_version.md
@@ -15,7 +15,7 @@ tmctl version [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_watch.md
+++ b/docs/tmctl_watch.md
@@ -22,7 +22,7 @@ tmctl watch
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.24.0")
+      --version string   TriggerMesh components version. (default "v1.24.4")
 ```
 
 ### SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
 	github.com/triggermesh/brokers v1.2.0
-	github.com/triggermesh/triggermesh v1.24.0
+	github.com/triggermesh/triggermesh v1.24.4
 	github.com/triggermesh/triggermesh-core v1.2.0
 	google.golang.org/api v0.108.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -1005,6 +1005,8 @@ github.com/triggermesh/brokers v1.2.0 h1:YzO+uiyw6e8tPO2Gt/sZxU2yO58EzExit/YT7eX
 github.com/triggermesh/brokers v1.2.0/go.mod h1:aL+X0l1Tss73Dva9fZ/aXbS3yu/aCE6cZVY+vZZD9Bk=
 github.com/triggermesh/triggermesh v1.24.0 h1:gSZt6SOF2d2FzuV8dMtqotKb7s3yBBN1Te2NPEBw9Pc=
 github.com/triggermesh/triggermesh v1.24.0/go.mod h1:QsT5rGh8b4EzsFIhutiV0jCyVFSTIG1yyt3+IACOlho=
+github.com/triggermesh/triggermesh v1.24.4 h1:4gwp6jg4lUZKyPS8XjYyBRdzvWKwFPfFefnyZtlrG94=
+github.com/triggermesh/triggermesh v1.24.4/go.mod h1:QsT5rGh8b4EzsFIhutiV0jCyVFSTIG1yyt3+IACOlho=
 github.com/triggermesh/triggermesh-core v1.2.0 h1:QdX8PaNs6Q0wwRutmNwfdx9JGyV7GX3GxaesOUCcefs=
 github.com/triggermesh/triggermesh-core v1.2.0/go.mod h1:4weCl+2VFvo2qCID3umRDPVKCTQCKuL5G5+eC+MAGLc=
 github.com/tsenart/go-tsz v0.0.0-20180814232043-cdeb9e1e981e/go.mod h1:SWZznP1z5Ki7hDT2ioqiFKEse8K9tU2OUvaRI0NeGQo=

--- a/pkg/triggermesh/adapter/ce/targets.go
+++ b/pkg/triggermesh/adapter/ce/targets.go
@@ -148,7 +148,15 @@ func targets(object unstructured.Unstructured) (EventAttributes, error) {
 			AcceptedEventTypes:  o.AcceptedEventTypes(),
 		}, nil
 	case "HTTPTarget":
-		return EventAttributes{}, nil
+		var o *targetsv1alpha1.HTTPTarget
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {
+			return EventAttributes{}, err
+		}
+		return EventAttributes{
+			ProducedEventTypes:  o.GetEventTypes(),
+			ProducedEventSource: o.AsEventSource(),
+			AcceptedEventTypes:  o.AcceptedEventTypes(),
+		}, nil
 	case "IBMMQTarget":
 		var o *targetsv1alpha1.IBMMQTarget
 		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(object.Object, &o); err != nil {

--- a/pkg/triggermesh/components/transformation/transformation.go
+++ b/pkg/triggermesh/components/transformation/transformation.go
@@ -320,18 +320,33 @@ func (t *Transformation) getContextTransformationValue(key string) []string {
 		return []string{}
 	}
 	for _, op := range contextTransformation.([]interface{}) {
-		if opp, ok := op.(map[string]interface{}); ok {
-			if opp["operation"] == "add" {
-				if p, ok := opp["paths"].([]interface{}); ok {
-					for _, pp := range p {
-						if pm, ok := pp.(map[string]interface{}); ok {
-							if pm["key"] == key {
-								return []string{pm["value"].(string)}
-							}
-						}
-					}
-				}
+		spec, ok := op.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if spec["operation"] != "add" {
+			continue
+		}
+		paths, ok := spec["paths"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, path := range paths {
+			pm, ok := path.(map[string]interface{})
+			if !ok {
+				continue
 			}
+			if pm["key"] != key {
+				continue
+			}
+			val, ok := pm["value"]
+			if !ok {
+				continue
+			}
+			if val == nil {
+				continue
+			}
+			return []string{val.(string)}
 		}
 	}
 	return []string{}


### PR DESCRIPTION
This PR contains transformation-related updates:
- triggermesh/triggermesh dependency updated to v1.24.4 version,
- updated HTTPTarget behavior (strict event type, schema, etc.) employed in the CLI's internals,
- CLI automatically sets CE context transformation to match produced and expected events.