### PR TITLE
`tmctl delete` command format update

### DIFF
--- a/cmd/delete/broker.go
+++ b/cmd/delete/broker.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delete
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/triggermesh/tmctl/pkg/completion"
+	"github.com/triggermesh/tmctl/pkg/manifest"
+	"github.com/triggermesh/tmctl/pkg/triggermesh"
+)
+
+func (o *CliOptions) deleteBrokerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "broker <name>",
+		Short:   "Delete TriggerMesh Broker",
+		Example: "tmctl delete broker foo",
+		Args:    cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return completion.ListObjectsByKind("RedisBroker", o.Manifest), cobra.ShellCompDirectiveNoFileComp
+		}, RunE: func(cmd *cobra.Command, args []string) error {
+			return o.deleteBroker(args[0])
+		},
+	}
+}
+
+func (o *CliOptions) deleteBroker(broker string) error {
+	oo := *o
+	oo.Config.Context = broker
+	oo.Manifest = manifest.New(filepath.Join(oo.Config.ConfigHome, broker, triggermesh.ManifestFile))
+	cobra.CheckErr(oo.Manifest.Read())
+
+	if err := oo.deleteBrokerComponents([]string{}, true); err != nil {
+		return fmt.Errorf("deleting component: %w", err)
+	}
+	if err := os.RemoveAll(filepath.Join(oo.Config.ConfigHome, broker)); err != nil {
+		return fmt.Errorf("delete broker %q: %v", broker, err)
+	}
+	if broker == o.Config.Context {
+		return o.switchContext()
+	}
+	return nil
+}

--- a/cmd/delete/source.go
+++ b/cmd/delete/source.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delete
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/triggermesh/tmctl/pkg/completion"
+	"github.com/triggermesh/tmctl/pkg/docker"
+)
+
+func (o *CliOptions) deleteSourceCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "source <name>",
+		Short:   "Delete TriggerMesh Source",
+		Example: "tmctl delete source foo",
+		Args:    cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return append(completion.ListObjectsByAPI("sources.triggermesh.io/v1alpha1", o.Manifest),
+					completion.ListObjectsByAPI("serving.knative.dev/v1", o.Manifest)...),
+				cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.deleteSources(args)
+		},
+	}
+}
+
+func (o *CliOptions) deleteSources(names []string) error {
+	ctx := context.Background()
+	client, err := docker.NewClient()
+	if err != nil {
+		return fmt.Errorf("docker client: %w", err)
+	}
+	for _, object := range o.Manifest.Objects {
+		if object.APIVersion != "sources.triggermesh.io/v1alpha1" &&
+			object.APIVersion != "serving.knative.dev/v1" {
+			continue
+		}
+		for _, name := range names {
+			if name == object.Metadata.Name {
+				o.deleteEverything(ctx, object, client)
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/delete/target.go
+++ b/cmd/delete/target.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delete
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/triggermesh/tmctl/pkg/completion"
+	"github.com/triggermesh/tmctl/pkg/docker"
+)
+
+func (o *CliOptions) deleteTargetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "target <name>",
+		Short:   "Delete TriggerMesh Target",
+		Example: "tmctl delete target foo",
+		Args:    cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return append(completion.ListObjectsByAPI("targets.triggermesh.io/v1alpha1", o.Manifest),
+					completion.ListObjectsByAPI("serving.knative.dev/v1", o.Manifest)...),
+				cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.deleteTarget(args)
+		},
+	}
+}
+
+func (o *CliOptions) deleteTarget(names []string) error {
+	ctx := context.Background()
+	client, err := docker.NewClient()
+	if err != nil {
+		return fmt.Errorf("docker client: %w", err)
+	}
+	for _, object := range o.Manifest.Objects {
+		if object.APIVersion != "targets.triggermesh.io/v1alpha1" &&
+			object.APIVersion != "serving.knative.dev/v1" {
+			continue
+		}
+		for _, name := range names {
+			if name == object.Metadata.Name {
+				o.deleteEverything(ctx, object, client)
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/delete/transformation.go
+++ b/cmd/delete/transformation.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delete
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/triggermesh/tmctl/pkg/completion"
+	"github.com/triggermesh/tmctl/pkg/docker"
+)
+
+func (o *CliOptions) deleteTransformationCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "transformation <name>",
+		Short:   "Delete TriggerMesh Transformation",
+		Example: "tmctl delete transformation foo",
+		Args:    cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return completion.ListObjectsByKind("Transformation", o.Manifest), cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.deleteTransformation(args)
+		},
+	}
+}
+
+func (o *CliOptions) deleteTransformation(names []string) error {
+	ctx := context.Background()
+	client, err := docker.NewClient()
+	if err != nil {
+		return fmt.Errorf("docker client: %w", err)
+	}
+	for _, object := range o.Manifest.Objects {
+		if object.Kind != "Transformation" {
+			continue
+		}
+		for _, name := range names {
+			if name == object.Metadata.Name {
+				o.deleteEverything(ctx, object, client)
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/cmd/delete/trigger.go
+++ b/cmd/delete/trigger.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package delete
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/triggermesh/tmctl/pkg/completion"
+	"github.com/triggermesh/tmctl/pkg/docker"
+)
+
+func (o *CliOptions) deleteTriggerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "trigger <name>",
+		Short:   "Delete TriggerMesh Trigger",
+		Example: "tmctl delete trigger foo",
+		Args:    cobra.MinimumNArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			return completion.ListObjectsByKind("Trigger", o.Manifest), cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.deleteTrigger(args)
+		},
+	}
+}
+
+func (o *CliOptions) deleteTrigger(names []string) error {
+	ctx := context.Background()
+	client, err := docker.NewClient()
+	if err != nil {
+		return fmt.Errorf("docker client: %w", err)
+	}
+	for _, object := range o.Manifest.Objects {
+		if object.Kind != "Trigger" {
+			continue
+		}
+		for _, name := range names {
+			if name == object.Metadata.Name {
+				o.deleteEverything(ctx, object, client)
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/docs/tmctl.md
+++ b/docs/tmctl.md
@@ -20,7 +20,7 @@ Find more information at: https://docs.triggermesh.io
 * [tmctl brokers](tmctl_brokers.md)	 - Show list and switch between existing brokers
 * [tmctl config](tmctl_config.md)	 - Read and write config values
 * [tmctl create](tmctl_create.md)	 - Create TriggerMesh component
-* [tmctl delete](tmctl_delete.md)	 - Delete components by names
+* [tmctl delete](tmctl_delete.md)	 - Delete TriggerMesh component
 * [tmctl describe](tmctl_describe.md)	 - List broker components and their statuses
 * [tmctl dump](tmctl_dump.md)	 - Generate TriggerMesh manifests
 * [tmctl import](tmctl_import.md)	 - Import TriggerMesh manifest

--- a/docs/tmctl_delete.md
+++ b/docs/tmctl_delete.md
@@ -1,23 +1,11 @@
 ## tmctl delete
 
-Delete components by names
-
-```
-tmctl delete <component_name_1, component_name_2...> [--broker <name>] [flags]
-```
-
-### Examples
-
-```
-tmctl delete foo-httptarget, foo-awss3source
-tmctl delete --broker foo
-```
+Delete TriggerMesh component
 
 ### Options
 
 ```
-      --broker string   Delete the broker
-  -h, --help            help for delete
+  -h, --help   help for delete
 ```
 
 ### Options inherited from parent commands
@@ -29,4 +17,9 @@ tmctl delete --broker foo
 ### SEE ALSO
 
 * [tmctl](tmctl.md)	 - A command line interface to build event-driven applications
+* [tmctl delete broker](tmctl_delete_broker.md)	 - Delete TriggerMesh Broker
+* [tmctl delete source](tmctl_delete_source.md)	 - Delete TriggerMesh Source
+* [tmctl delete target](tmctl_delete_target.md)	 - Delete TriggerMesh Target
+* [tmctl delete transformation](tmctl_delete_transformation.md)	 - Delete TriggerMesh Transformation
+* [tmctl delete trigger](tmctl_delete_trigger.md)	 - Delete TriggerMesh Trigger
 

--- a/docs/tmctl_delete_broker.md
+++ b/docs/tmctl_delete_broker.md
@@ -1,0 +1,30 @@
+## tmctl delete broker
+
+Delete TriggerMesh Broker
+
+```
+tmctl delete broker <name> [flags]
+```
+
+### Examples
+
+```
+tmctl delete broker foo
+```
+
+### Options
+
+```
+  -h, --help   help for broker
+```
+
+### Options inherited from parent commands
+
+```
+      --version string   TriggerMesh components version. (default "v1.24.4")
+```
+
+### SEE ALSO
+
+* [tmctl delete](tmctl_delete.md)	 - Delete TriggerMesh component
+

--- a/docs/tmctl_delete_source.md
+++ b/docs/tmctl_delete_source.md
@@ -1,0 +1,30 @@
+## tmctl delete source
+
+Delete TriggerMesh Source
+
+```
+tmctl delete source <name> [flags]
+```
+
+### Examples
+
+```
+tmctl delete source foo
+```
+
+### Options
+
+```
+  -h, --help   help for source
+```
+
+### Options inherited from parent commands
+
+```
+      --version string   TriggerMesh components version. (default "v1.24.4")
+```
+
+### SEE ALSO
+
+* [tmctl delete](tmctl_delete.md)	 - Delete TriggerMesh component
+

--- a/docs/tmctl_delete_target.md
+++ b/docs/tmctl_delete_target.md
@@ -1,0 +1,30 @@
+## tmctl delete target
+
+Delete TriggerMesh Target
+
+```
+tmctl delete target <name> [flags]
+```
+
+### Examples
+
+```
+tmctl delete target foo
+```
+
+### Options
+
+```
+  -h, --help   help for target
+```
+
+### Options inherited from parent commands
+
+```
+      --version string   TriggerMesh components version. (default "v1.24.4")
+```
+
+### SEE ALSO
+
+* [tmctl delete](tmctl_delete.md)	 - Delete TriggerMesh component
+

--- a/docs/tmctl_delete_transformation.md
+++ b/docs/tmctl_delete_transformation.md
@@ -1,0 +1,30 @@
+## tmctl delete transformation
+
+Delete TriggerMesh Transformation
+
+```
+tmctl delete transformation <name> [flags]
+```
+
+### Examples
+
+```
+tmctl delete transformation foo
+```
+
+### Options
+
+```
+  -h, --help   help for transformation
+```
+
+### Options inherited from parent commands
+
+```
+      --version string   TriggerMesh components version. (default "v1.24.4")
+```
+
+### SEE ALSO
+
+* [tmctl delete](tmctl_delete.md)	 - Delete TriggerMesh component
+

--- a/docs/tmctl_delete_trigger.md
+++ b/docs/tmctl_delete_trigger.md
@@ -1,0 +1,30 @@
+## tmctl delete trigger
+
+Delete TriggerMesh Trigger
+
+```
+tmctl delete trigger <name> [flags]
+```
+
+### Examples
+
+```
+tmctl delete trigger foo
+```
+
+### Options
+
+```
+  -h, --help   help for trigger
+```
+
+### Options inherited from parent commands
+
+```
+      --version string   TriggerMesh components version. (default "v1.24.4")
+```
+
+### SEE ALSO
+
+* [tmctl delete](tmctl_delete.md)	 - Delete TriggerMesh component
+

--- a/pkg/completion/completion.go
+++ b/pkg/completion/completion.go
@@ -61,6 +61,26 @@ func ListTargets(m *manifest.Manifest) []string {
 	return list
 }
 
+func ListObjectsByAPI(api string, m *manifest.Manifest) []string {
+	var list []string
+	for _, object := range m.Objects {
+		if object.APIVersion == api {
+			list = append(list, object.Metadata.Name)
+		}
+	}
+	return list
+}
+
+func ListObjectsByKind(kind string, m *manifest.Manifest) []string {
+	var list []string
+	for _, object := range m.Objects {
+		if object.Kind == kind {
+			list = append(list, object.Metadata.Name)
+		}
+	}
+	return list
+}
+
 func ListAll(m *manifest.Manifest) []string {
 	var list []string
 	for _, object := range m.Objects {

--- a/test/e2e/run_e2e_test.sh
+++ b/test/e2e/run_e2e_test.sh
@@ -124,7 +124,7 @@ validate_start() {
 cleanup() {
     echo "Cleaning up test environment"
     kill -INT $WATCH_PID
-    $TMCTL delete --broker e2e-test
+    $TMCTL delete broker e2e-test
 
     BROKERS="`$TMCTL brokers`"
     if [ ! -z "$BROKERS" ]; then


### PR DESCRIPTION
`tmctl delete` command, now being consistent with the `create` format, expects the component's kind and name args to execute the deletion, e.g.:

```sh
tmctl delete source foo
tmctl delete transformation bar
tmctl delete broker baz
```
etc.