### PR TITLE
`tmctl dump -p kubernetes-generic` 

### DIFF
--- a/pkg/triggermesh/components/broker/broker.go
+++ b/pkg/triggermesh/components/broker/broker.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/digitalocean/godo"
@@ -121,6 +122,17 @@ func (b *Broker) AsDigitalOceanObject(additionalEnvs map[string]string) (interfa
 		InstanceCount:    1,
 		InstanceSizeSlug: "professional-xs",
 	}, nil
+}
+
+func (b *Broker) AsKubernetesDeployment(additionalEnvs map[string]string) (interface{}, error) {
+	var envs []corev1.EnvVar
+	for k, v := range additionalEnvs {
+		envs = append(envs, corev1.EnvVar{Name: k, Value: v})
+	}
+
+	deployment := kubernetes.CreateDeployment(b.Name, b.image, envs)
+	deployment.Spec.Template.Spec.Containers[0].Command = b.entrypoint
+	return deployment, nil
 }
 
 func (b *Broker) asContainer(additionalEnvs map[string]string) (*docker.Container, error) {

--- a/pkg/triggermesh/components/service/service.go
+++ b/pkg/triggermesh/components/service/service.go
@@ -147,6 +147,14 @@ func (s *Service) AsDigitalOceanObject(additionalEnvs map[string]string) (interf
 	}, nil
 }
 
+func (s *Service) AsKubernetesDeployment(additionalEnvs map[string]string) (interface{}, error) {
+	envs := []corev1.EnvVar{}
+	for k, v := range additionalEnvs {
+		envs = append(envs, corev1.EnvVar{Name: k, Value: v})
+	}
+	return kubernetes.CreateDeployment(s.Name, s.Image, envs), nil
+}
+
 func (s *Service) asContainer(additionalEnvs map[string]string) (*docker.Container, error) {
 	u, err := s.asUnstructured()
 	if err != nil {

--- a/pkg/triggermesh/components/target/target.go
+++ b/pkg/triggermesh/components/target/target.go
@@ -161,6 +161,36 @@ func (t *Target) AsDigitalOceanObject(additionalEnvs map[string]string) (interfa
 	}, nil
 }
 
+func (t *Target) AsKubernetesDeployment(additionalEnvs map[string]string) (interface{}, error) {
+	o, err := t.asUnstructured()
+	if err != nil {
+		return nil, fmt.Errorf("creating object: %w", err)
+	}
+	image := adapter.Image(o, t.Version)
+
+	adapterEnv, err := env.Build(o)
+	if err != nil {
+		return nil, fmt.Errorf("adapter environment: %w", err)
+	}
+
+	envs := []corev1.EnvVar{}
+	for _, v := range adapterEnv {
+		if v.ValueFrom != nil && additionalEnvs != nil {
+			if secret, ok := additionalEnvs[v.ValueFrom.SecretKeyRef.Key]; ok {
+				envs = append(envs, corev1.EnvVar{Name: v.Name, Value: string(secret)})
+				delete(additionalEnvs, v.ValueFrom.SecretKeyRef.Key)
+			}
+		} else {
+			envs = append(envs, v)
+		}
+	}
+	for k, v := range additionalEnvs {
+		envs = append(envs, corev1.EnvVar{Name: k, Value: v})
+	}
+
+	return kubernetes.CreateDeployment(t.Name, image, envs), nil
+}
+
 func (t *Target) asContainer(additionalEnvs map[string]string) (*docker.Container, error) {
 	o, err := t.asUnstructured()
 	if err != nil {

--- a/pkg/triggermesh/interfaces.go
+++ b/pkg/triggermesh/interfaces.go
@@ -77,4 +77,5 @@ type Reconcilable interface {
 type Exportable interface {
 	AsDockerComposeObject(additionalEnvs map[string]string) (interface{}, error)
 	AsDigitalOceanObject(additionalEnvs map[string]string) (interface{}, error)
+	AsKubernetesDeployment(additionalEnvs map[string]string) (interface{}, error)
 }


### PR DESCRIPTION
Experimental, low-effort feature that enables TriggerMesh integration deployment on any Kubernetes clusters with no prerequisites - `tmctl dump -p kubernetes-generic` produces vanilla Kubernetes Deployment objects. Can be `| kubectl apply -f -`'d on "empty" Minikube. One detail to keep in mind - if integration components require external services reconciliation, this process will take place in the CLI during initial creation, just like in any other cases.