### PR TITLE
cleanup the wiretap container specific to the broker in case of tmctl stop

### DIFF
--- a/cmd/stop/stop.go
+++ b/cmd/stop/stop.go
@@ -72,6 +72,11 @@ func (o *CliOptions) stop() error {
 			continue
 		}
 		if object.Kind == tmbroker.BrokerKind {
+			wiretapContainerName := object.Metadata.Name + "-wiretap"
+			if err := docker.ForceStop(ctx, wiretapContainerName, client); err != nil {
+				log.Printf("Stopping %q: %v", wiretapContainerName, err)
+			}
+
 			object.Metadata.Name += "-broker"
 		}
 		log.Printf("Stopping %s\n", object.Metadata.Name)

--- a/docs/tmctl.md
+++ b/docs/tmctl.md
@@ -12,7 +12,7 @@ Find more information at: https://docs.triggermesh.io
 
 ```
   -h, --help             help for tmctl
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_brokers.md
+++ b/docs/tmctl_brokers.md
@@ -16,7 +16,7 @@ tmctl brokers [--set <broker>] [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_config.md
+++ b/docs/tmctl_config.md
@@ -15,7 +15,7 @@ tmctl config [set|get] [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_config_get.md
+++ b/docs/tmctl_config_get.md
@@ -15,7 +15,7 @@ tmctl config get [key] [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_config_set.md
+++ b/docs/tmctl_config_set.md
@@ -15,7 +15,7 @@ tmctl config set <key> <value> [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create.md
+++ b/docs/tmctl_create.md
@@ -11,7 +11,7 @@ Create TriggerMesh component
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create_source.md
+++ b/docs/tmctl_create_source.md
@@ -25,7 +25,7 @@ tmctl create source httppoller \
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create_target.md
+++ b/docs/tmctl_create_target.md
@@ -24,7 +24,7 @@ tmctl create target http \
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create_transformation.md
+++ b/docs/tmctl_create_transformation.md
@@ -33,7 +33,7 @@ EOF
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_create_trigger.md
+++ b/docs/tmctl_create_trigger.md
@@ -26,7 +26,7 @@ tmctl create trigger --target sockeye --source foo-httppollersource
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_delete.md
+++ b/docs/tmctl_delete.md
@@ -11,7 +11,7 @@ Delete TriggerMesh component
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_delete_broker.md
+++ b/docs/tmctl_delete_broker.md
@@ -21,7 +21,7 @@ tmctl delete broker foo
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_delete_source.md
+++ b/docs/tmctl_delete_source.md
@@ -21,7 +21,7 @@ tmctl delete source foo
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_delete_target.md
+++ b/docs/tmctl_delete_target.md
@@ -21,7 +21,7 @@ tmctl delete target foo
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_delete_transformation.md
+++ b/docs/tmctl_delete_transformation.md
@@ -21,7 +21,7 @@ tmctl delete transformation foo
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_delete_trigger.md
+++ b/docs/tmctl_delete_trigger.md
@@ -21,7 +21,7 @@ tmctl delete trigger foo
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_describe.md
+++ b/docs/tmctl_describe.md
@@ -21,7 +21,7 @@ tmctl describe
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_dump.md
+++ b/docs/tmctl_dump.md
@@ -26,7 +26,7 @@ tmctl dump
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_import.md
+++ b/docs/tmctl_import.md
@@ -22,7 +22,7 @@ tmctl import -f manifest.yaml
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_logs.md
+++ b/docs/tmctl_logs.md
@@ -22,7 +22,7 @@ tmctl logs
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_send-event.md
+++ b/docs/tmctl_send-event.md
@@ -23,7 +23,7 @@ tmctl send-event '{"hello":"world"}'
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_start.md
+++ b/docs/tmctl_start.md
@@ -22,7 +22,7 @@ tmctl start
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_stop.md
+++ b/docs/tmctl_stop.md
@@ -21,7 +21,7 @@ tmctl stop
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_version.md
+++ b/docs/tmctl_version.md
@@ -15,7 +15,7 @@ tmctl version [flags]
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO

--- a/docs/tmctl_watch.md
+++ b/docs/tmctl_watch.md
@@ -22,7 +22,7 @@ tmctl watch
 ### Options inherited from parent commands
 
 ```
-      --version string   TriggerMesh components version. (default "v1.25.0")
+      --version string   TriggerMesh components version. (default "v1.25.1")
 ```
 
 ### SEE ALSO


### PR DESCRIPTION
### Description
This PR adds changes to clean up the wiretap container specific to a broker when `tmctl stop` is used to stop a broker container.

### Motivation
Fixes: #205