### PR TITLE
add file flag to send-event to specify file containing multiple events

### DIFF
--- a/docs/tmctl_send-event.md
+++ b/docs/tmctl_send-event.md
@@ -3,7 +3,7 @@
 Send CloudEvent to the target
 
 ```
-tmctl send-event [--eventType <type>][--target <name>] <data> [flags]
+tmctl send-event [--eventType <type>][--target <name>][--file <filename>] <data> [flags]
 ```
 
 ### Examples
@@ -16,6 +16,7 @@ tmctl send-event '{"hello":"world"}'
 
 ```
       --eventType string   CloudEvent Type attribute (default "triggermesh-local-event")
+  -f, --file string        File containing a list of events
   -h, --help               help for send-event
       --target string      Component to send the event to. Default is the broker
 ```


### PR DESCRIPTION
### Description
This PR adds  `-f` flag to the `send-event` command for specifying the file containing events.

### Motivation
Fixes: #220