### PR TITLE
remove the unnecessary argument in the CreateTrigger func in wiretap

### DIFF
--- a/cmd/watch/watch.go
+++ b/cmd/watch/watch.go
@@ -38,9 +38,6 @@ import (
 
 type CliOptions struct {
 	Config *config.Config
-
-	EventTypes string
-	Source     string
 }
 
 type brokerLog struct {
@@ -67,7 +64,6 @@ func NewCmd(config *config.Config) *cobra.Command {
 			return o.watch()
 		},
 	}
-	watchCmd.Flags().StringVarP(&o.EventTypes, "eventTypes", "e", "", "Filter events based on type attribute")
 	return watchCmd
 }
 
@@ -92,7 +88,7 @@ func (o *CliOptions) watch() error {
 	if err != nil {
 		return fmt.Errorf("create container: %w", err)
 	}
-	if err := w.CreateTrigger(strings.Split(o.EventTypes, ",")); err != nil {
+	if err := w.CreateTrigger(); err != nil {
 		return fmt.Errorf("create trigger: %w", err)
 	}
 	brokerLogs, err := w.BrokerLogs(ctx, o.Config.Triggermesh.Broker)

--- a/docs/tmctl_watch.md
+++ b/docs/tmctl_watch.md
@@ -15,8 +15,7 @@ tmctl watch
 ### Options
 
 ```
-  -e, --eventTypes string   Filter events based on type attribute
-  -h, --help                help for watch
+  -h, --help   help for watch
 ```
 
 ### Options inherited from parent commands

--- a/pkg/wiretap/wiretap.go
+++ b/pkg/wiretap/wiretap.go
@@ -82,7 +82,7 @@ func (w *Wiretap) CreateAdapter(ctx context.Context) (io.ReadCloser, error) {
 	return c.Logs(ctx, w.client, time.Now().Add(2*time.Second), true)
 }
 
-func (w *Wiretap) CreateTrigger(eventTypes []string) error {
+func (w *Wiretap) CreateTrigger() error {
 	url, err := apis.ParseURL(w.Destination)
 	if err != nil {
 		return fmt.Errorf("wiretap URL: %w", err)


### PR DESCRIPTION
[CreateTrigger](https://github.com/triggermesh/tmctl/blob/main/pkg/wiretap/wiretap.go#L85) function has an unnecessary parameter. 
Maybe forgot to remove it after the function structure was changed.