### PR TITLE
use --version arg in start command to specify broker image version

### DIFF
--- a/cmd/start/start.go
+++ b/cmd/start/start.go
@@ -42,6 +42,7 @@ type CliOptions struct {
 }
 
 func NewCmd(config *config.Config, m *manifest.Manifest, crd map[string]crd.CRD) *cobra.Command {
+	var version string
 	o := &CliOptions{
 		CRD:      crd,
 		Config:   config,
@@ -64,19 +65,22 @@ func NewCmd(config *config.Config, m *manifest.Manifest, crd map[string]crd.CRD)
 					triggermesh.ManifestFile))
 			}
 			cobra.CheckErr(o.Manifest.Read())
-			return o.start()
+			return o.start(version)
 		},
 	}
 	startCmd.Flags().BoolVar(&o.Restart, "restart", false, "Restart components")
+	startCmd.Flags().StringVar(&version, "version", o.Config.Triggermesh.Broker.Version, "TriggerMesh broker version.")
+
 	return startCmd
 }
 
-func (o *CliOptions) start() error {
+func (o *CliOptions) start(version string) error {
 	ctx := context.Background()
 	var brokerPort string
 	// start eventing first
 	for _, object := range o.Manifest.Objects {
 		if object.Kind == tmbroker.BrokerKind {
+			o.Config.Triggermesh.Broker.Version = version
 			b, err := tmbroker.New(object.Metadata.Name, o.Config.Triggermesh.Broker)
 			if err != nil {
 				return fmt.Errorf("creating broker object: %w", err)


### PR DESCRIPTION
### Description
This PR make changes in `tmctl start` to use `--version` arg, to specify the broker version.

### Before
```
> tmctl start foo --version v1.2.0 --restart
2023/07/04 01:41:21 foo | Starting broker
> docker ps
CONTAINER ID   IMAGE                                                            COMMAND                  CREATED
 STATUS             PORTS                     NAMES
e50ca6b0625d   gcr.io/triggermesh/memory-broker:v1.3.0                          "/memory-broker star…"   8 seconds ago       Up 7 seconds       0.0.0.0:45093->8080/tcp   foo-broker
```
### After
```
> tmctl start foo --version v1.2.0 --restart
2023/07/04 01:41:21 foo | Starting broker
> docker ps
CONTAINER ID   IMAGE                                                            COMMAND                  CREATED
 STATUS             PORTS                     NAMES
e50ca6b0625d   gcr.io/triggermesh/memory-broker:v1.2.0                          "/memory-broker star…"   8 seconds ago       Up 7 seconds       0.0.0.0:45093->8080/tcp   foo-broker
```